### PR TITLE
Multi-dimensional split groundwork

### DIFF
--- a/.idea/dictionaries/vadim.xml
+++ b/.idea/dictionaries/vadim.xml
@@ -11,6 +11,7 @@
       <w>pegjs</w>
       <w>poped</w>
       <w>uber</w>
+      <w>unsuppress</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,5 +3,6 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="JSJQueryEfficiency" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSMethodCanBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSUnfilteredForInLoop" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,11 @@
 # 0.6.3
 
 - Changed JS fallbacks in DruidExternal to use native code generators and removed some null bugs. 
+
+# 0.7.1
+
+- Paving the road for multi-dimensional splits `.split({ Page: '$page', User: '$user' })`
+- Fixed problems with SELECT queries
+- Allow for SQL parsing of `SELECT *`
+- Fix support for `sort` and `limit` in SELECT queries
+- Better escaping in MySQL driver

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plywood",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "split-apply-combine; unify data and vis; with single language",
   "keywords": [
     "split",

--- a/src/actions/applyAction.ts
+++ b/src/actions/applyAction.ts
@@ -55,7 +55,7 @@ module Plywood {
     }
 
     protected _getSQLHelper(dialect: SQLDialect, inputSQL: string, expressionSQL: string): string {
-      return `${expressionSQL} AS '${this.name}'`;
+      return `${expressionSQL} AS ${JSON.stringify(this.name)}`;
     }
 
     public isSimpleAggregate(): boolean {

--- a/src/actions/applyAction.ts
+++ b/src/actions/applyAction.ts
@@ -55,7 +55,7 @@ module Plywood {
     }
 
     protected _getSQLHelper(dialect: SQLDialect, inputSQL: string, expressionSQL: string): string {
-      return `${expressionSQL} AS ${JSON.stringify(this.name)}`;
+      return `${expressionSQL} AS ${dialect.escapeLiteral(this.name)}`;
     }
 
     public isSimpleAggregate(): boolean {

--- a/src/actions/baseAction.ts
+++ b/src/actions/baseAction.ts
@@ -2,11 +2,20 @@
 /// <reference path="../expressions/baseExpression.ts" />
 
 module Plywood {
+  export interface Splits {
+    [name: string]: Expression;
+  }
+
+  export interface SplitsJS {
+    [name: string]: ExpressionJS;
+  }
+
   export interface ActionValue {
     action?: string;
     name?: string;
     dataName?: string;
     expression?: Expression;
+    splits?: Splits;
     direction?: string;
     limit?: int;
     size?: number;
@@ -32,6 +41,7 @@ module Plywood {
     name?: string;
     dataName?: string;
     expression?: ExpressionJS;
+    splits?: SplitsJS;
     direction?: string;
     limit?: int;
     size?: number;
@@ -380,13 +390,21 @@ module Plywood {
       return simpleExpression.performAction(this, true);
     }
 
+    public getExpressions(): Expression[] {
+      return this.expression ? [this.expression] : [];
+    }
 
     public getFreeReferences(): string[] {
-      return this.expression ? this.expression.getFreeReferences() : [];
+      var freeReferences: string[] = [];
+      this.getExpressions().forEach((ex) => {
+        freeReferences = freeReferences.concat(ex.getFreeReferences());
+      });
+      return deduplicateSort(freeReferences);
     }
 
     public _everyHelper(iter: BooleanExpressionIterator, thisArg: any, indexer: Indexer, depth: int, nestDiff: int): boolean {
-      return this.expression ? this.expression._everyHelper(iter, thisArg, indexer, depth, nestDiff + Number(this.isNester())) : true;
+      var nestDiffNext = nestDiff + Number(this.isNester());
+      return this.getExpressions().every((ex) => ex._everyHelper(iter, thisArg, indexer, depth, nestDiffNext));
     }
 
     /**

--- a/src/actions/inAction.ts
+++ b/src/actions/inAction.ts
@@ -42,14 +42,14 @@ module Plywood {
         case 'NUMBER_RANGE':
           if (expression instanceof LiteralExpression) {
             var numberRange: NumberRange = expression.value;
-            return dialect.inExpression(inputSQL, numberToSQL(numberRange.start), numberToSQL(numberRange.end), numberRange.bounds);
+            return dialect.inExpression(inputSQL, dialect.numberToSQL(numberRange.start), dialect.numberToSQL(numberRange.end), numberRange.bounds);
           }
           throw new Error('not implemented yet');
 
         case 'TIME_RANGE':
           if (expression instanceof LiteralExpression) {
             var timeRange: TimeRange = expression.value;
-            return dialect.inExpression(inputSQL, timeToSQL(timeRange.start), timeToSQL(timeRange.end), timeRange.bounds);
+            return dialect.inExpression(inputSQL, dialect.timeToSQL(timeRange.start), dialect.timeToSQL(timeRange.end), timeRange.bounds);
           }
           throw new Error('not implemented yet');
 

--- a/src/actions/splitAction.ts
+++ b/src/actions/splitAction.ts
@@ -1,32 +1,73 @@
 module Plywood {
+  function splitsFromJS(splitsJS: SplitsJS): Splits {
+    var splits: Splits = Object.create(null);
+    for (var name in splitsJS) {
+      if (!hasOwnProperty(splitsJS, name)) continue;
+      splits[name] = Expression.fromJS(splitsJS[name]);
+    }
+    return splits;
+  }
+
+  function splitsEqual(splitsA: Splits, splitsB: Splits): boolean {
+    var keysA = Object.keys(splitsA);
+    var keysB = Object.keys(splitsB);
+    if (keysA.length !== keysB.length) return false;
+    for (var k of keysA) {
+      if (!splitsA[k].equals(splitsB[k])) return false;
+    }
+    return true;
+  }
+
+
   export class SplitAction extends Action {
     static fromJS(parameters: ActionJS): SplitAction {
-      var value = Action.jsToValue(parameters);
-      value.name = parameters.name;
+      var value: ActionValue = {
+        action: parameters.action
+      };
+      var splits: SplitsJS;
+      if (parameters.expression && parameters.name) {
+        splits = { [parameters.name]: parameters.expression };
+      } else {
+        splits = parameters.splits;
+      }
+      value.splits = splitsFromJS(splits);
       value.dataName = parameters.dataName;
       return new SplitAction(value);
     }
 
-    public name: string;
+    public keys: string[];
+    public splits: Splits;
     public dataName: string;
 
     constructor(parameters: ActionValue) {
       super(parameters, dummyObject);
-      this.name = parameters.name;
+      var splits = parameters.splits;
+      if (!splits) throw new Error('must have splits');
+      this.splits = splits;
+      this.keys = Object.keys(splits).sort();
+      if (!this.keys.length) throw new Error('must have at least one split');
       this.dataName = parameters.dataName;
       this._ensureAction("split");
     }
 
     public valueOf(): ActionValue {
       var value = super.valueOf();
-      value.name = this.name;
+      value.splits = this.splits;
       value.dataName = this.dataName;
       return value;
     }
 
     public toJS(): ActionJS {
       var js = super.toJS();
-      js.name = this.name;
+      if (this.isMultiSplit()) {
+        js.splits = this.mapSplitExpressions((ex) => ex.toJS());
+      } else {
+        var { splits } = this;
+        for (var name in splits) {
+          js.name = name;
+          js.expression = splits[name].toJS();
+        }
+      }
       js.dataName = this.dataName;
       return js;
     }
@@ -37,45 +78,155 @@ module Plywood {
     }
 
     protected _toStringParameters(expressionString: string): string[] {
-      return [expressionString, this.name, this.dataName];
+      if (this.isMultiSplit()) {
+        var { splits } = this;
+        var splitStrings: string[] = [];
+        for (var name in splits) {
+          splitStrings.push(`${name}: ${splits[name].toString()}`);
+        }
+        return [splitStrings.join(', '), this.dataName];
+      } else {
+        return [this.firstSplitExpression().toString(), this.firstSplitName(), this.dataName];
+      }
     }
 
     public equals(other: SplitAction): boolean {
       return super.equals(other) &&
-        this.name === other.name &&
+        splitsEqual(this.splits, other.splits) &&
         this.dataName === other.dataName;
     }
 
-    protected _getFnHelper(inputFn: ComputeFn, expressionFn: ComputeFn): ComputeFn {
-      var name = this.name;
-      var dataName = this.dataName;
+    public getFn(inputFn: ComputeFn): ComputeFn {
+      var { dataName } = this;
+      var splitFns = this.mapSplitExpressions((ex) => ex.getFn());
       return (d: Datum, c: Datum) => {
         var inV = inputFn(d, c);
-        return inV ? inV.split(expressionFn, name, dataName) : null;
+        return inV ? inV.split(splitFns, dataName) : null;
       }
     }
 
     public _fillRefSubstitutions(typeContext: FullType, indexer: Indexer, alterations: Alterations): FullType {
       var newDatasetType: Lookup<FullType> = {};
-      var splitFullType = this.expression._fillRefSubstitutions(typeContext, indexer, alterations);
-      newDatasetType[this.name] = splitFullType;
+      this.mapSplits((name, expression) => {
+        newDatasetType[name] = expression._fillRefSubstitutions(typeContext, indexer, alterations);
+      });
       newDatasetType[this.dataName] = typeContext;
 
       return {
         parent: typeContext.parent,
         type: 'DATASET',
         datasetType: newDatasetType,
-        remote: splitFullType.remote
+        remote: null
       };
     }
 
-    protected _getSQLHelper(dialect: SQLDialect, inputSQL: string, expressionSQL: string): string {
-      throw `GROUP BY ${expressionSQL}`;
+    public getSQL(inputSQL: string, dialect: SQLDialect): string {
+      var groupBys = this.mapSplits((name, expression) => expression.getSQL(dialect));
+      return `GROUP BY ${groupBys.join(', ')}`;
+    }
+
+    public getSelectSQL(dialect: SQLDialect): string[] {
+      return this.mapSplits((name, expression) => `${expression.getSQL(dialect)} AS ${JSON.stringify(name)}`);
+    }
+
+    public getShortGroupBySQL(): string {
+      return 'GROUP BY ' + Object.keys(this.splits).map((d, i) => i + 1).join(', ');
+    }
+
+    public expressionCount(): int {
+      var count = 0;
+      this.mapSplits((k, expression) => {
+        count += expression.expressionCount();
+      });
+      return count;
+    }
+
+    public simplify(): Action {
+      if (this.simple) return this;
+
+      var simpleSplits = this.mapSplitExpressions((ex) => ex.simplify());
+
+      var value = this.valueOf();
+      value.splits = simpleSplits;
+      value.simple = true;
+      return new SplitAction(value);
+    }
+
+    public getExpressions(): Expression[] {
+      return this.mapSplits((name, ex) => ex);
+    }
+
+    public _substituteHelper(substitutionFn: SubstitutionFn, thisArg: any, indexer: Indexer, depth: int, nestDiff: int): Action {
+      var nestDiffNext = nestDiff + 1;
+      var hasChanged = false;
+      var subSplits = this.mapSplitExpressions((ex) => {
+        var subExpression = ex._substituteHelper(substitutionFn, thisArg, indexer, depth, nestDiffNext);
+        if (subExpression !== ex) hasChanged = true;
+        return subExpression;
+      });
+      if (!hasChanged) return this;
+      var value = this.valueOf();
+      value.splits = subSplits;
+      return new SplitAction(value);
+    }
+
+    public applyToExpression(transformation: ExpressionTransformation): Action {
+      var hasChanged = false;
+      var newSplits = this.mapSplitExpressions((ex) => {
+        var newExpression = transformation(ex);
+        if (newExpression !== ex) hasChanged = true;
+        return newExpression;
+      });
+      if (!hasChanged) return this;
+      var value = this.valueOf();
+      value.splits = newSplits;
+      return new SplitAction(value);
     }
 
     public isNester(): boolean {
       return true;
     }
+
+    public numSplits(): number {
+      return this.keys.length;
+    }
+
+    public isMultiSplit(): boolean {
+      return this.numSplits() > 1;
+    }
+
+    public mapSplits<T>(fn: (name: string, expression?: Expression) => T): T[] {
+      var { splits, keys } = this;
+      return keys.map((k) => fn(k, splits[k]));
+    }
+
+    public mapSplitExpressions<T>(fn: (expression: Expression, name?: string) => T): Lookup<T> {
+      var { splits, keys } = this;
+      var ret: Lookup<T> = Object.create(null);
+      for (var key of keys) {
+        ret[key] = fn(splits[key], key);
+      }
+      return ret;
+    }
+
+    public firstSplitName(): string {
+      return this.keys[0];
+    }
+
+    public firstSplitExpression(): Expression {
+      return this.splits[this.firstSplitName()];
+    }
+
+    public filterFromDatum(datum: Datum): Expression {
+      return Expression.and(this.mapSplits((name, expression) => {
+        return expression.is(r(datum[name]));
+      })).simplify();
+    }
+
+    public hasKey(key: string): boolean {
+      return hasOwnProperty(this.splits, key);
+    }
+
   }
 
   Action.register(SplitAction);

--- a/src/actions/splitAction.ts
+++ b/src/actions/splitAction.ts
@@ -126,7 +126,7 @@ module Plywood {
     }
 
     public getSelectSQL(dialect: SQLDialect): string[] {
-      return this.mapSplits((name, expression) => `${expression.getSQL(dialect)} AS ${JSON.stringify(name)}`);
+      return this.mapSplits((name, expression) => `${expression.getSQL(dialect)} AS ${dialect.escapeLiteral(name)}`);
     }
 
     public getShortGroupBySQL(): string {

--- a/src/datatypes/common.ts
+++ b/src/datatypes/common.ts
@@ -111,20 +111,6 @@ module Plywood {
     return v;
   }
 
-  export function numberToSQL(num: number): string {
-    if (num === null) return null;
-    return String(num);
-  }
-
-  export function timeToSQL(date: Date): string {
-    if (!date) return null;
-    var str = date.toISOString()
-      .replace("T", " ")
-      .replace(/\.\d\d\dZ$/, "")
-      .replace(" 00:00:00", "");
-    return "'" + str + "'";
-  }
-
   // Remote functionality
 
   export function datumHasExternal(datum: Datum): boolean {

--- a/src/datatypes/external.ts
+++ b/src/datatypes/external.ts
@@ -70,6 +70,13 @@ module Plywood {
           return 'something';
         }
 
+      case 'SET/STRING':
+        if (ex instanceof RefExpression) {
+          return Set.fromJS([ex.name + '1']);
+        } else {
+          return Set.fromJS(['something']);
+        }
+
       default:
         throw new Error("unsupported simulation on: " + valueType);
     }
@@ -350,6 +357,12 @@ module Plywood {
         if (attribute.name === attributeName) return attribute;
       }
       return null;
+    }
+
+    public show(): External {
+      var value = this.valueOf();
+      value.suppress = false;
+      return <External>(new (External.classMap[this.engine])(value));
     }
 
     // -----------------

--- a/src/dialect/sqlDialect.ts
+++ b/src/dialect/sqlDialect.ts
@@ -3,13 +3,40 @@ module Plywood {
     constructor() {
     }
 
+    public escapeName(name: string): string {
+      if (name.indexOf('`') !== -1) throw new Error("can not convert to SQL"); // ToDo: fix this
+      return '`' + name + '`';
+    }
+
+    public escapeLiteral(name: string): string {
+      return JSON.stringify(name);
+    }
+
+    public booleanToSQL(bool: boolean): string {
+      return ('' + bool).toUpperCase();
+    }
+
+    public numberToSQL(num: number): string {
+      if (num === null) return 'NULL';
+      return '' + num;
+    }
+
+    public timeToSQL(date: Date): string {
+      if (!date) return 'NULL';
+      var str = date.toISOString()
+        .replace("T", " ")
+        .replace(/\.\d\d\dZ$/, "")
+        .replace(" 00:00:00", "");
+      return "'" + str + "'";
+    }
+
     public inExpression(operand: string, start: string, end: string, bounds: string) {
       var startSQL: string = null;
-      if (start !== null) {
+      if (start !== 'NULL') {
         startSQL = start + (bounds[0] === '[' ? '<=' : '<') + operand;
       }
       var endSQL: string = null;
-      if (end !== null) {
+      if (end !== 'NULL') {
         endSQL = operand + (bounds[1] === ']' ? '<=' : '<') + end;
       }
       if (startSQL) {

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -793,13 +793,29 @@ module Plywood {
       return this.performAction(new CustomAction({ custom }));
     }
 
-    public split(ex: any, name: string, newDataName: string = null): ChainExpression {
-      if (!Expression.isExpression(ex)) ex = Expression.fromJSLoose(ex);
-      var dataName = getDataName(this);
-      if (!dataName && !newDataName) {
-        throw new Error("could not guess data name in `split`, please provide one explicitly");
+    public split(splits: any, dataName?: string): ChainExpression;
+    public split(ex: any, name: string, dataName?: string): ChainExpression;
+    public split(splits: any, name?: string, dataName?: string): ChainExpression {
+      // Determine if use case #2
+      if (arguments.length === 3 ||
+        (arguments.length === 2 && splits && (typeof splits === 'string' || typeof splits.op === 'string'))) {
+        var realSplits = Object.create(null);
+        realSplits[name] = splits;
+        splits = realSplits;
+      } else {
+        dataName = name;
       }
-      return this.performAction(new SplitAction({ expression: ex, name, dataName: newDataName || dataName }));
+
+      var parsedSplits: Splits = Object.create(null);
+      for (var k in splits) {
+        if (!hasOwnProperty(splits, k)) continue;
+        var ex = splits[k];
+        parsedSplits[k] = Expression.isExpression(ex) ? ex : Expression.fromJSLoose(ex);
+      }
+
+      if (!dataName) dataName = getDataName(this);
+      if (!dataName) throw new Error("could not guess data name in `split`, please provide one explicitly");
+      return this.performAction(new SplitAction({ splits: parsedSplits, dataName: dataName }));
     }
 
     public is(ex: any): ChainExpression {

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -1062,7 +1062,12 @@ module Plywood {
       }
 
       var simulatedQueries: any[] = [];
-      this.referenceCheck(context).resolve(context).simplify()._computeResolvedSimulate(simulatedQueries);
+      var readyExpression = this.referenceCheck(context).resolve(context).simplify();
+      if (readyExpression instanceof ExternalExpression) {
+        // Top level externals need to be unsuppressed
+        readyExpression = (<ExternalExpression>readyExpression).unsuppress()
+      }
+      readyExpression._computeResolvedSimulate(simulatedQueries);
       return simulatedQueries;
     }
 
@@ -1089,7 +1094,12 @@ module Plywood {
       }
       var ex = this;
       return introspectDatum(context).then(introspectedContext => {
-        return ex.referenceCheck(introspectedContext).resolve(introspectedContext).simplify()._computeResolved();
+        var readyExpression = ex.referenceCheck(introspectedContext).resolve(introspectedContext).simplify();
+        if (readyExpression instanceof ExternalExpression) {
+          // Top level externals need to be unsuppressed
+          readyExpression = (<ExternalExpression>readyExpression).unsuppress()
+        }
+        return readyExpression._computeResolved();
       });
     }
   }

--- a/src/expressions/chainExpression.ts
+++ b/src/expressions/chainExpression.ts
@@ -307,7 +307,7 @@ module Plywood {
           for (let action of actions) {
             if (action instanceof SplitAction) {
               nextData = applyName;
-              nextKey = action.name;
+              nextKey = action.firstSplitName();
               depth++;
             } else if (action instanceof ApplyAction) {
               action.expression._collectBindSpecs(bindSpecs, selectionDepth, depth, action.name, nextData, nextKey);

--- a/src/expressions/externalExpression.ts
+++ b/src/expressions/externalExpression.ts
@@ -21,7 +21,7 @@ module Plywood {
 
     public valueOf(): ExpressionValue {
       var value = super.valueOf();
-      value.value = this.external;
+      value.external = this.external;
       return value;
     }
 
@@ -62,6 +62,12 @@ module Plywood {
       var external = this.external;
       if (external.suppress) return Q(external);
       return external.queryValues();
+    }
+
+    public unsuppress(): ExternalExpression {
+      var value = this.valueOf();
+      value.external = this.external.show();
+      return new ExternalExpression(value);
     }
 
     public addAction(action: Action): ExternalExpression {

--- a/src/expressions/literalExpression.ts
+++ b/src/expressions/literalExpression.ts
@@ -70,25 +70,25 @@ module Plywood {
       var value = this.value;
       switch (this.type) {
         case 'STRING':
-          return JSON.stringify(value);
+          return dialect.escapeLiteral(value);
 
         case 'BOOLEAN':
-          return String(value).toUpperCase();
+          return dialect.booleanToSQL(value);
 
         case 'NUMBER':
-          return String(value);
+          return dialect.numberToSQL(value);
 
         case 'NUMBER_RANGE':
-          return String(value.start) + '/' + String(value.end);
+          return `${dialect.numberToSQL(value.start)}/${dialect.numberToSQL(value.end)}`;
 
         case 'TIME':
-          return timeToSQL(<Date>value);
+          return dialect.timeToSQL(<Date>value);
 
         case 'TIME_RANGE':
-          return timeToSQL(value.start) + '/' + timeToSQL(value.end);
+          return `${dialect.timeToSQL(value.start)}/${dialect.timeToSQL(value.end)}`;
 
         case 'SET/STRING':
-          return '(' + (<Set>value).elements.map((v: string) => JSON.stringify(v)).join(',') + ')';
+          return '(' + (<Set>value).elements.map((v: string) => dialect.escapeLiteral(v)).join(',') + ')';
 
         default:
           throw new Error("currently unsupported type: " + this.type);

--- a/src/expressions/refExpression.ts
+++ b/src/expressions/refExpression.ts
@@ -166,9 +166,7 @@ module Plywood {
 
     public getSQL(dialect: SQLDialect, minimal: boolean = false): string {
       if (this.nest) throw new Error(`can not call getSQL on unresolved expression: ${this.toString()}`);
-      var name = this.name;
-      if (name.indexOf('`') !== -1) throw new Error("can not convert to SQL");
-      return '`' + name + '`';
+      return dialect.escapeName(this.name);
     }
 
     public equals(other: RefExpression): boolean {

--- a/src/expressions/sql.pegjs
+++ b/src/expressions/sql.pegjs
@@ -112,7 +112,8 @@ function constructQuery(columns, from, where, groupBys, having, orderBy, limit) 
   if (!groupBys) {
     query = from;
   } else {
-    if (columns === '*') error('can not SELECT * with a group by');
+    if (columns === '*') error('can not SELECT * with a GROUP BY');
+
     if (groupBys.length === 1 && groupBys[0].isOp('literal')) {
       query = ply().apply('data', from);
     } else {
@@ -125,13 +126,14 @@ function constructQuery(columns, from, where, groupBys, having, orderBy, limit) 
       }
       query = from.split(splits, 'data');
     }
-  }
 
-  if (Array.isArray(columns)) {
-    for (var i = 0; i < columns.length; i++) {
-      query = query.performAction(columns[i]);
+    if (Array.isArray(columns)) {
+      for (var i = 0; i < columns.length; i++) {
+        query = query.performAction(columns[i]);
+      }
     }
   }
+
   if (having) {
     query = query.performAction(having);
   }

--- a/src/external/druidExternal.ts
+++ b/src/external/druidExternal.ts
@@ -414,7 +414,7 @@ module Plywood {
 
     public canHandleSort(sortAction: SortAction): boolean {
       var split = this.split;
-      if (split.isMultiSplit()) return true;
+      if (!split || split.isMultiSplit()) return true;
       var splitExpression = split.firstSplitExpression();
       var label = split.firstSplitName();
       if (splitExpression instanceof ChainExpression) {
@@ -436,7 +436,7 @@ module Plywood {
 
     public canHandleLimit(limitAction: LimitAction): boolean {
       var split = this.split;
-      if (split.isMultiSplit()) return true;
+      if (!split || split.isMultiSplit()) return true;
       var splitExpression = split.firstSplitExpression();
       if (splitExpression instanceof ChainExpression) {
         if (splitExpression.getExpressionPattern('concat')) return true;
@@ -718,7 +718,7 @@ return (start < 0 ?'-':'') + parts.join('.');
 
       var split = this.split;
       if (split.isMultiSplit()) {
-        throw new Error('not implemented multi-dim split yet');
+        throw new Error('not implemented multi-dim split yet... but we are so very close');
       }
 
       var label = split.firstSplitName();
@@ -1340,14 +1340,14 @@ return (start < 0 ?'-':'') + parts.join('.');
       switch (this.mode) {
         case 'raw':
           if (!this.allowSelectQueries) {
-            throw new Error("can issue make 'select' queries unless allowSelectQueries flag is set");
+            throw new Error("to issues 'select' queries allowSelectQueries flag must be set");
           }
           druidQuery.queryType = 'select';
           druidQuery.dimensions = [];
           druidQuery.metrics = [];
           druidQuery.pagingSpec = {
             "pagingIdentifiers": {},
-            "threshold": 10000
+            "threshold": this.limit ? this.limit.limit : 10000
           };
 
           return {

--- a/src/external/mySqlExternal.ts
+++ b/src/external/mySqlExternal.ts
@@ -138,10 +138,16 @@ module Plywood {
       var query = ['SELECT'];
       switch (this.mode) {
         case 'raw':
-          query.push('`' + Object.keys(this.attributes).join('`, `') + '`');
+          query.push(this.attributes.map(a => mySQLDialect.escapeName(a.name)).join(', '));
           query.push('FROM ' + table);
           if (!(this.filter.equals(Expression.TRUE))) {
             query.push('WHERE ' + this.filter.getSQL(mySQLDialect));
+          }
+          if (this.sort) {
+            query.push(this.sort.getSQL('', mySQLDialect));
+          }
+          if (this.limit) {
+            query.push(this.limit.getSQL('', mySQLDialect));
           }
           break;
 

--- a/test/actions/actions.mocha.coffee
+++ b/test/actions/actions.mocha.coffee
@@ -9,17 +9,31 @@ describe "Actions", ->
   it "passes higher object tests", ->
     testImmutableClass(Action, [
       {
-        action: 'apply'
-        name: 'Five'
-        expression: { op: 'literal', value: 5 }
-      }
-      {
         action: 'filter'
         expression: {
           op: 'chain'
           expression: { op: 'ref', name: 'myVar' }
           action: { action: 'is', expression: { op: 'literal', value: 5 } }
         }
+      }
+      {
+        action: 'split'
+        name: 'Page'
+        expression: { op: 'ref', name: 'page' }
+        dataName: 'myData'
+      }
+      {
+        action: 'split'
+        splits: {
+          'Page': { op: 'ref', name: 'page' }
+          'User': { op: 'ref', name: 'user' }
+        }
+        dataName: 'myData'
+      }
+      {
+        action: 'apply'
+        name: 'Five'
+        expression: { op: 'literal', value: 5 }
       }
       {
         action: 'sort'

--- a/test/overall/composition.mocha.coffee
+++ b/test/overall/composition.mocha.coffee
@@ -45,6 +45,31 @@ describe "composition", ->
       ]
     })
 
+  it "works in of a set", ->
+    ex = $("x").in(['A', 'B', 'C'])
+    expect(ex.toJS()).to.deep.equal({
+      "action": {
+        "action": "in"
+        "expression": {
+          "op": "literal"
+          "type": "SET"
+          "value": {
+            "elements": [
+              "A"
+              "B"
+              "C"
+            ]
+            "setType": "STRING"
+          }
+        }
+      }
+      "expression": {
+        "name": "x"
+        "op": "ref"
+      }
+      "op": "chain"
+    })
+
   it "works in single split case", ->
     ex = $('data')
       .split('$page', 'Page', 'd')

--- a/test/overall/composition.mocha.coffee
+++ b/test/overall/composition.mocha.coffee
@@ -45,6 +45,53 @@ describe "composition", ->
       ]
     })
 
+  it "works in single split case", ->
+    ex = $('data')
+      .split('$page', 'Page', 'd')
+
+    expect(ex.toJS()).to.deep.equal({
+      "action": {
+        "action": "split"
+        "dataName": "d"
+        "expression": {
+          "name": "page"
+          "op": "ref"
+        }
+        "name": "Page"
+      }
+      "expression": {
+        "name": "data"
+        "op": "ref"
+      }
+      "op": "chain"
+    })
+
+  it "works in multi split case", ->
+    ex = $('data')
+      .split({ Page: '$page', User: '$page' }, 'd')
+
+    expect(ex.toJS()).to.deep.equal({
+      "action": {
+        "action": "split"
+        "dataName": "d"
+        "splits": {
+          "Page": {
+            "name": "page"
+            "op": "ref"
+          }
+          "User": {
+            "name": "page"
+            "op": "ref"
+          }
+        }
+      }
+      "expression": {
+        "name": "data"
+        "op": "ref"
+      }
+      "op": "chain"
+    })
+
   it "works in semi-realistic case", ->
     ex = ply()
       .apply("Diamonds",

--- a/test/overall/compute.mocha.coffee
+++ b/test/overall/compute.mocha.coffee
@@ -75,6 +75,7 @@ describe "compute native", ->
     ds = Dataset.fromJS(data).hide()
 
     ex = ply()
+      .apply('Two', 2)
       .apply('Data', ply(ds))
       .apply('Cuts'
         $('Data').split('$cut', 'Cut')
@@ -88,6 +89,7 @@ describe "compute native", ->
     p.then((v) ->
       expect(v.toJS()).to.deep.equal([
         {
+          "Two": 2
           "Cuts": [
             {
               "Cut": "Good"

--- a/test/overall/sqlParser.mocha.coffee
+++ b/test/overall/sqlParser.mocha.coffee
@@ -54,11 +54,6 @@ describe "SQL parser", ->
         Expression.parseSQL("SELECT FROM wiki")
       ).to.throw('SQL parse error: Can not have empty column list on `SELECT FROM wiki`')
 
-    it "should fail gracefully on expressions with multi-dimensional GROUP BYs", ->
-      expect(->
-        Expression.parseSQL("SELECT page, user FROM wiki GROUP BY page, user")
-      ).to.throw('plywood does not currently support multi-dimensional GROUP BYs')
-
     it "should have a good error for incorrect numeric GROUP BYs", ->
       expect(->
         Expression.parseSQL("SELECT page, COUNT() AS 'Count' FROM wiki GROUP BY 12")
@@ -254,6 +249,15 @@ describe "SQL parser", ->
       ex2 = $('wiki').split('$page', 'Page', 'data')
         .apply('TotalAdded', '$data.sum($added)')
         .limit(5)
+
+      expect(parse.expression.toJS()).to.deep.equal(ex2.toJS())
+
+    it "should work with multi-dimensional GROUP BYs", ->
+      parse = Expression.parseSQL("""
+        SELECT `page`, `user` FROM `wiki` GROUP BY `page`, `user`
+        """)
+
+      ex2 = $('wiki').split({ page: '$page', user: '$user' }, 'data')
 
       expect(parse.expression.toJS()).to.deep.equal(ex2.toJS())
 

--- a/test/simulate/simulateMySQL.mocha.coffee
+++ b/test/simulate/simulateMySQL.mocha.coffee
@@ -65,12 +65,12 @@ describe "simulate MySQL", ->
 
     expect(queryPlan[0]).to.equal("""
       SELECT
-      COUNT(*) AS 'Count',
-      SUM(`price`) AS 'TotalPrice',
-      (SUM(`price`)*2) AS 'PriceTimes2',
-      (SUM(`price`)-SUM(`tax`)) AS 'PriceMinusTax',
-      (((SUM(`price`)-SUM(`tax`))+10)-SUM(`carat`)) AS 'Crazy',
-      (SUM(`price`)+SUM(`tax`)) AS 'PriceAndTax'
+      COUNT(*) AS "Count",
+      SUM(`price`) AS "TotalPrice",
+      (SUM(`price`)*2) AS "PriceTimes2",
+      (SUM(`price`)-SUM(`tax`)) AS "PriceMinusTax",
+      (((SUM(`price`)-SUM(`tax`))+10)-SUM(`carat`)) AS "Crazy",
+      (SUM(`price`)+SUM(`tax`)) AS "PriceAndTax"
       FROM `diamonds`
       WHERE (`color`="D")
       GROUP BY ''
@@ -78,33 +78,33 @@ describe "simulate MySQL", ->
 
     expect(queryPlan[1]).to.equal("""
       SELECT
-      `cut` AS 'Cut',
-      COUNT(*) AS 'Count',
-      (4/`Count`) AS 'PercentOfTotal'
+      `cut` AS "Cut",
+      COUNT(*) AS "Count",
+      (4/`Count`) AS "PercentOfTotal"
       FROM `diamonds`
       WHERE (`color`="D")
-      GROUP BY `cut`
+      GROUP BY 1
       ORDER BY `Count` DESC
       LIMIT 2
       """)
 
     expect(queryPlan[2]).to.equal("""
       SELECT
-      DATE_FORMAT(CONVERT_TZ(`time`, '+0:00', 'America/Los_Angeles'), '%Y-%m-%dT00:00:00Z') AS 'Timestamp',
-      SUM(`price`) AS 'TotalPrice'
+      DATE_FORMAT(CONVERT_TZ(`time`, '+0:00', 'America/Los_Angeles'), '%Y-%m-%dT00:00:00Z') AS "Timestamp",
+      SUM(`price`) AS "TotalPrice"
       FROM `diamonds`
       WHERE ((`color`="D") AND (`cut`="some_cut"))
-      GROUP BY DATE_FORMAT(CONVERT_TZ(`time`, '+0:00', 'America/Los_Angeles'), '%Y-%m-%dT00:00:00Z')
+      GROUP BY 1
       ORDER BY `Timestamp` ASC
       """)
 
     expect(queryPlan[3]).to.equal("""
       SELECT
-      FLOOR(`carat` / 0.25) * 0.25 AS 'Carat',
-      COUNT(*) AS 'Count'
+      FLOOR(`carat` / 0.25) * 0.25 AS "Carat",
+      COUNT(*) AS "Count"
       FROM `diamonds`
       WHERE (((`color`="D") AND (`cut`="some_cut")) AND ('2015-03-13 07:00:00'<=`time` AND `time`<'2015-03-14 07:00:00'))
-      GROUP BY FLOOR(`carat` / 0.25) * 0.25
+      GROUP BY 1
       ORDER BY `Count` DESC
       LIMIT 3
       """)
@@ -122,10 +122,10 @@ describe "simulate MySQL", ->
 
     expect(queryPlan[0]).to.equal("""
       SELECT
-      `cut` AS 'Cut',
-      COUNT(*) AS 'Count'
+      `cut` AS "Cut",
+      COUNT(*) AS "Count"
       FROM `diamonds`
-      GROUP BY `cut`
+      GROUP BY 1
       HAVING 100<`Count`
       ORDER BY `Count` DESC
       LIMIT 10
@@ -151,20 +151,20 @@ describe "simulate MySQL", ->
 
     expect(queryPlan[0]).to.equal("""
       SELECT
-      `height_bucket` AS 'HeightBucket',
-      COUNT(*) AS 'Count'
+      `height_bucket` AS "HeightBucket",
+      COUNT(*) AS "Count"
       FROM `diamonds`
-      GROUP BY `height_bucket`
+      GROUP BY 1
       ORDER BY `Count` DESC
       LIMIT 10
       """)
 
     expect(queryPlan[1]).to.equal("""
       SELECT
-      FLOOR((`height_bucket` - 0.5) / 2) * 2 + 0.5 AS 'HeightBucket',
-      COUNT(*) AS 'Count'
+      FLOOR((`height_bucket` - 0.5) / 2) * 2 + 0.5 AS "HeightBucket",
+      COUNT(*) AS "Count"
       FROM `diamonds`
-      GROUP BY FLOOR((`height_bucket` - 0.5) / 2) * 2 + 0.5
+      GROUP BY 1
       ORDER BY `Count` DESC
       LIMIT 10
       """)


### PR DESCRIPTION
Many things here:

- Paving the road for multi-dimensional splits `.split({ Page: '$page', User: '$user' })`
- Fixed problems with SELECT queries
- Allow for SQL parsing of `SELECT *`
- Fix support for `sort` and `limit` in SELECT queries
- Better escaping in MySQL driver