### PR TITLE
fix contains signature so compare is optional

### DIFF
--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -860,7 +860,7 @@ module Plywood {
       return this.performAction(new GreaterThanOrEqualAction({ expression: ex }));
     }
 
-    public contains(ex: any, compare: string): ChainExpression {
+    public contains(ex: any, compare?: string): ChainExpression {
       if (!Expression.isExpression(ex)) ex = Expression.fromJSLoose(ex);
       return this.performAction(new ContainsAction({ expression: ex, compare }));
     }


### PR DESCRIPTION
this keeps webstorm, etc, from complaining if contains is used without 2 arguments, since the compare value is optional on the ContainsAction