### PR TITLE
Fix typo in output example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -213,7 +213,7 @@ The output will look like so:
   {
     "Count": 573775,
     "TotalAdded": 124184252,
-    "Page": [
+    "Pages": [
       {
         "Page": "Wikipedia:Vandalismusmeldung",
         "Count": 177


### PR DESCRIPTION
For `.apply('Pages', ...)`, the output should include a `Pages` property