### PR TITLE
better set support in PlyQL

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,8 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="CssInvalidHtmlTagReference" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssInvalidPseudoSelector" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="JSClosureCompilerSyntax" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSJQueryEfficiency" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSMethodCanBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.9.24
+
+- Added SET expressions to PlyQL `{'A', 'B', 'C'}`
+- PlyQL can now parse IN with arbitrary right expression on
+
 ## 0.9.23
 
 - Fix .match() not working on SET/STRING 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "istanbul": "0.4.2",
     "mocha": "2.4.5",
     "pegjs": "0.9.0",
-    "plywood-druid-requester": "1.4.1",
+    "plywood-druid-requester": "1.4.2",
     "plywood-mysql-requester": "1.2.2",
     "tslint": "3.6.0",
     "typescript": "1.8.9",

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -733,6 +733,10 @@ module Plywood {
       return this;
     }
 
+    public bumpStringLiteralToSetString(): Expression {
+      return this;
+    }
+
     // ------------------------------------------------------------------------
     // API behaviour
 
@@ -877,7 +881,7 @@ module Plywood {
 
     public overlap(ex: any): ChainExpression {
       if (!Expression.isExpression(ex)) ex = Expression.fromJSLoose(ex);
-      return this.performAction(new OverlapAction({ expression: ex }));
+      return this.bumpStringLiteralToSetString().performAction(new OverlapAction({ expression: ex.bumpStringLiteralToSetString() }));
     }
 
     public not(): ChainExpression {

--- a/src/expressions/literalExpression.ts
+++ b/src/expressions/literalExpression.ts
@@ -147,6 +147,11 @@ module Plywood {
       if (!parse) throw new Error(`could not parse '${this.value}' as string`);
       return r(parse);
     }
+
+    public bumpStringLiteralToSetString(): Expression {
+      if (this.type !== 'STRING') return this;
+      return r(Set.fromJS([this.value]));
+    }
   }
 
   Expression.NULL = new LiteralExpression({ value: null });

--- a/src/expressions/plyql.pegjs
+++ b/src/expressions/plyql.pegjs
@@ -164,6 +164,7 @@ function makeList(head, tail) {
 }
 
 function makeListMap1(head, tail) {
+  if (head == null) return [];
   return [head].concat(tail.map(function(t) { return t[1] }));
 }
 
@@ -345,7 +346,7 @@ ComparisonExpressionRhsNotable
       var range = { start: start.value, end: end.value, bounds: '[]' };
       return { call: 'in', args: [range] };
     }
-  / InToken list:ListLiteral
+  / InToken list:(InListLiteralExpression / AdditiveExpression)
     {
       return { call: 'in', args: [list] };
     }
@@ -373,10 +374,6 @@ ComparisonOp
   / ">="  { return 'greaterThanOrEqual'; }
   / "<"   { return 'lessThan'; }
   / ">"   { return 'greaterThan'; }
-
-ListLiteral
-  = OpenParen head:StringOrNumber tail:(Comma StringOrNumber)* CloseParen
-    { return r(Set.fromJS(makeListMap1(head, tail))); }
 
 
 AdditiveExpression
@@ -543,13 +540,16 @@ LiteralExpression
     { return r(makeDate(type, v)); }
   / type:(DateToken / TimeToken / TimestampToken) v:String
     { return r(makeDate(type, v)); }
-  / number:Number
-    { return r(number); }
-  / string:String
-    { return r(string); }
-  / v:(NullToken / TrueToken / FalseToken)
+  / v:(Number / String / ListLiteral / NullToken / TrueToken / FalseToken)
     { return r(v); }
 
+ListLiteral
+  = OpenCurly head:StringOrNumber? tail:(Comma StringOrNumber)* CloseCurly
+    { return Set.fromJS(makeListMap1(head, tail)); }
+
+InListLiteralExpression
+  = OpenParen head:StringOrNumber tail:(Comma StringOrNumber)* CloseParen
+    { return r(Set.fromJS(makeListMap1(head, tail))); }
 
 String "String"
   = "'" chars:NotSQuote "'" _ { return chars; }

--- a/test/overall/composition.mocha.js
+++ b/test/overall/composition.mocha.js
@@ -37,6 +37,48 @@ describe("composition", () => {
     });
   });
 
+  it("it bumps lessThan to time", () => {
+    var ex = r("2016").lessThan('$x');
+    expect(ex.toJS()).to.deep.equal({
+      "action": {
+        "action": "lessThan",
+        "expression": {
+          "name": "x",
+          "op": "ref"
+        }
+      },
+      "expression": {
+        "op": "literal",
+        "value": new Date('2016-01-01T00:00:00.000Z')
+      },
+      "op": "chain"
+    });
+  });
+
+  it("overlap to SET", () => {
+    var ex = r("hello").overlap('$x');
+    expect(ex.toJS()).to.deep.equal({
+      "action": {
+        "action": "overlap",
+        "expression": {
+          "name": "x",
+          "op": "ref"
+        }
+      },
+      "expression": {
+        "op": "literal",
+        "type": "SET",
+        "value": {
+          "elements": [
+            "hello"
+          ],
+          "setType": "STRING"
+        }
+      },
+      "op": "chain"
+    });
+  });
+
   it("works in uber-basic case", () => {
     var ex = ply()
       .apply('five', 5)


### PR DESCRIPTION
- Added SET expressions to PlyQL `{'A', 'B', 'C'}`
- PlyQL can now parse IN with arbitrary expression on right hand side