### PR TITLE
Better plyql parser

### DIFF
--- a/.idea/dictionaries/vadim.xml
+++ b/.idea/dictionaries/vadim.xml
@@ -4,7 +4,10 @@
       <w>actionize</w>
       <w>amplab</w>
       <w>backtick</w>
+      <w>curdate</w>
       <w>datas</w>
+      <w>dayofmonth</w>
+      <w>dayofyear</w>
       <w>destructuring</w>
       <w>fallbacks</w>
       <w>inflater</w>
@@ -25,6 +28,7 @@
       <w>unsplitable</w>
       <w>unsuppress</w>
       <w>uservisits</w>
+      <w>weekofyear</w>
     </words>
   </dictionary>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
 
+## 0.9.25
+
+- Dramatically reduced PlyQL parser size
+- Added `YEAR` as a possible `timePart` value
+- Added `CURDATE`, `PI`, `YEAR`, `MONTH`, `WEEK_OF_YEAR`, `DAY_OF_YEAR`, `DAY_OF_MONTH`,
+  `DAY_OF_WEEK`, `HOUR`, `MINUTE`, `SECOND`, `DATE`, `CURRENT_TIMESTAMP`, `LOCALTIME`,
+  `LOCALTIMESTAMP`, `UTC_TIMESTAMP`, `SYSDATE`, `CURRENT_DATE`, `UTC_DATE`, `DAY_OF_YEAR`,
+  `DOY`, `DOW`, `DAYOFMONTH`, `DAY`, `WEEKOFYEAR`, and `WEEK` to PlyQL
+- Fixed bug where `DAY_OF_YEAR`, `DAY_OF_MONTH`, and `DAY_OF_WEEK` was zero indexed
+
 ## 0.9.24
 
 - Added SET expressions to PlyQL `{'A', 'B', 'C'}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
   `LOCALTIMESTAMP`, `UTC_TIMESTAMP`, `SYSDATE`, `CURRENT_DATE`, `UTC_DATE`, `DAY_OF_YEAR`,
   `DOY`, `DOW`, `DAYOFMONTH`, `DAY`, `WEEKOFYEAR`, and `WEEK` to PlyQL
 - Fixed bug where `DAY_OF_YEAR`, `DAY_OF_MONTH`, and `DAY_OF_WEEK` was zero indexed
+- Added support for `timeFloor` split in Druid external
 
 ## 0.9.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Change Log
 
+For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
+
 ## 0.9.24
 
 - Added SET expressions to PlyQL `{'A', 'B', 'C'}`
-- PlyQL can now parse IN with arbitrary right expression on
+- PlyQL can now parse IN with arbitrary expression on right hand side
 
 ## 0.9.23
 

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -410,6 +410,7 @@ The possible part values are:
 * `DAY_OF_WEEK`, `DAY_OF_MONTH`, `DAY_OF_YEAR`
 * `WEEK_OF_MONTH`, `WEEK_OF_YEAR`
 * `MONTH_OF_YEAR`
+* `YEAR`
 
 ```javascript
 var ex = $('time').timePart('DAY_OF_WEEK');

--- a/docs/plyql.md
+++ b/docs/plyql.md
@@ -469,6 +469,7 @@ The possible part values are:
 * `DAY_OF_WEEK`, `DAY_OF_MONTH`, `DAY_OF_YEAR`
 * `WEEK_OF_MONTH`, `WEEK_OF_YEAR`
 * `MONTH_OF_YEAR`
+* `YEAR`
 
 
 **TIME_FLOOR**(operand, duration, timezone)

--- a/src/dialect/sqlDialect.ts
+++ b/src/dialect/sqlDialect.ts
@@ -136,7 +136,7 @@ module Plywood {
       return timePartFunction.replace(/\$\$/g, this.timezoneConvert(operand, timezone));
     }
 
-    public timeShiftExpression(operand: string, duration: Duration, timezone: Timezone  ): string {
+    public timeShiftExpression(operand: string, duration: Duration, timezone: Timezone): string {
       // https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_date-add
       var sqlFn = "DATE_ADD("; //warpDirection > 0 ? "DATE_ADD(" : "DATE_SUB(";
       var spans = duration.valueOf();

--- a/src/dialect/sqlDialect.ts
+++ b/src/dialect/sqlDialect.ts
@@ -100,14 +100,15 @@ module Plywood {
       HOUR_OF_MONTH: '((DAYOFMONTH($$)-1)*24+HOUR($$))',
       HOUR_OF_YEAR: '((DAYOFYEAR($$)-1)*24+HOUR($$))',
 
-      DAY_OF_WEEK: 'WEEKDAY($$)',
-      DAY_OF_MONTH: '(DAYOFMONTH($$)-1)',
-      DAY_OF_YEAR: '(DAYOFYEAR($$)-1)',
+      DAY_OF_WEEK: '(WEEKDAY($$)+1)',
+      DAY_OF_MONTH: 'DAYOFMONTH($$)',
+      DAY_OF_YEAR: 'DAYOFYEAR($$)',
 
       WEEK_OF_MONTH: null,
       WEEK_OF_YEAR: 'WEEK($$)', // ToDo: look into mode (https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_week)
 
-      MONTH_OF_YEAR: 'MONTH($$)'
+      MONTH_OF_YEAR: 'MONTH($$)',
+      YEAR: 'YEAR($$)'
     };
 
     constructor() {

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -103,6 +103,9 @@ module Plywood {
     if (param instanceof LiteralExpression && param.type === 'STRING') {
       return param.value;
     }
+    if (param instanceof RefExpression && param.nest === 0) {
+      return param.name;
+    }
     throw new Error('could not extract a string out of ' + String(param));
   }
 

--- a/src/expressions/plyql.pegjs
+++ b/src/expressions/plyql.pegjs
@@ -217,10 +217,6 @@ function constructQuery(distinct, columns, from, where, groupBys, having, orderB
   return query;
 }
 
-function makeList(head, tail) {
-  return [head].concat(tail);
-}
-
 function makeListMap1(head, tail) {
   if (head == null) return [];
   return [head].concat(tail.map(function(t) { return t[1] }));
@@ -316,8 +312,8 @@ WhereClause
     { return filter; }
 
 GroupByClause
-  = GroupToken ByToken head:Expression tail:ExpressionParameter*
-    { return makeList(head, tail); }
+  = GroupToken ByToken head:Expression tail:(Comma Expression)*
+    { return makeListMap1(head, tail); }
 
 HavingClause
   = HavingToken having:Expression

--- a/src/external/mySqlExternal.ts
+++ b/src/external/mySqlExternal.ts
@@ -1,8 +1,6 @@
 module Plywood {
   var mySQLDialect = new MySQLDialect();
 
-  const DEFAULT_TIMEZONE = Timezone.UTC;
-
   interface SQLDescribeRow {
     Field: string;
     Type: string;
@@ -14,15 +12,14 @@ module Plywood {
 
   function getSplitInflaters(split: SplitAction): Inflater[] {
     return split.mapSplits((label, splitExpression) => {
-      if (splitExpression.type === 'BOOLEAN') {
-        return External.booleanInflaterFactory(label);
-      }
+      var simpleInflater = External.getSimpleInflater(splitExpression, label);
+      if (simpleInflater) return simpleInflater;
 
       if (splitExpression instanceof ChainExpression) {
         var lastAction = splitExpression.lastAction();
 
         if (lastAction instanceof TimeBucketAction) {
-          return External.timeRangeInflaterFactory(label, lastAction.duration, lastAction.timezone || DEFAULT_TIMEZONE);
+          return External.timeRangeInflaterFactory(label, lastAction.duration, lastAction.getTimezone());
         }
 
         if (lastAction instanceof NumberBucketAction) {

--- a/test/external/druidExternal.mocha.js
+++ b/test/external/druidExternal.mocha.js
@@ -1756,7 +1756,7 @@ describe("DruidExternal", () => {
       expect(query.dimensions[0]).to.deep.equal({
         "dimension": "__time",
         "extractionFn": {
-          "format": "e'~",
+          "format": "e",
           "locale": "en-US",
           "timeZone": "Etc/UTC",
           "type": "timeFormat"

--- a/test/functional/crossFunctional.mocha.js
+++ b/test/functional/crossFunctional.mocha.js
@@ -26,12 +26,12 @@ var mySqlRequester = mySqlRequesterFactory({
   password: info.mySqlPassword
 });
 
-//druidRequester = helper.verboseRequesterFactory({
-//  requester: druidRequester
-//});
-//mySqlRequester = helper.verboseRequesterFactory({
-//  requester: mySqlRequester
-//});
+// druidRequester = helper.verboseRequesterFactory({
+//   requester: druidRequester
+// });
+// mySqlRequester = helper.verboseRequesterFactory({
+//   requester: mySqlRequester
+// });
 
 var attributes = [
   { name: 'time', type: 'TIME' },
@@ -414,6 +414,21 @@ describe("Cross Functional", function() {
         .limit(20) // To force a topN (for now)
     }));
 
+    it('works with TIME split (raw) (sort on split)', equalityTest({
+      executorNames: ['druid', 'mysql'],
+      expression: $('wiki').filter('$time < "2015-09-12T02Z"').split($("time"), 'TimeRaw')
+        .apply('TotalEdits', '$wiki.sum($count)')
+        .sort('$TimeRaw', 'ascending')
+    }));
+
+    it('works with TIME split (timeFloor) (sort on split)', equalityTest({
+      executorNames: ['druid', 'mysql'],
+      expression: $('wiki').split($("time").timeFloor('PT1H', 'Etc/UTC'), 'TimeFloorHour')
+        .apply('TotalEdits', '$wiki.sum($count)')
+        .apply('TotalAdded', '$wiki.sum($added)')
+        .sort('$TimeFloorHour', 'ascending')
+    }));
+
     it('works with TIME split (timeBucket) (sort on split)', equalityTest({
       executorNames: ['druid', 'mysql'],
       expression: $('wiki').split($("time").timeBucket('PT1H', 'Etc/UTC'), 'TimeByHour')
@@ -437,6 +452,42 @@ describe("Cross Functional", function() {
         .apply('TotalEdits', '$wiki.sum($count)')
         .apply('TotalAdded', '$wiki.sum($added)')
         .sort('$HourOfDay', 'ascending')
+    }));
+
+    it('works with TIME split (timePart(YEAR)) (sort on split)', equalityTest({
+      executorNames: ['druid', 'mysql'],
+      expression: $('wiki').split($("time").timePart('YEAR'), 'TimePart')
+        .apply('TotalEdits', '$wiki.sum($count)')
+        .sort('$TimePart', 'ascending')
+    }));
+
+    it('works with TIME split (timePart(DAY_OF_YEAR)) (sort on split)', equalityTest({
+      executorNames: ['druid', 'mysql'],
+      expression: $('wiki').split($("time").timePart('DAY_OF_YEAR'), 'TimePart')
+        .apply('TotalEdits', '$wiki.sum($count)')
+        .sort('$TimePart', 'ascending')
+    }));
+
+    it('works with TIME split (timePart(DAY_OF_MONTH)) (sort on split)', equalityTest({
+      executorNames: ['druid', 'mysql'],
+      expression: $('wiki').split($("time").timePart('DAY_OF_MONTH'), 'TimePart')
+        .apply('TotalEdits', '$wiki.sum($count)')
+        .sort('$TimePart', 'ascending')
+    }));
+
+    it('works with TIME split (timePart(DAY_OF_WEEK)) (sort on split)', equalityTest({
+      executorNames: ['druid', 'mysql'],
+      expression: $('wiki').split($("time").timePart('DAY_OF_WEEK'), 'TimePart')
+        .apply('TotalEdits', '$wiki.sum($count)')
+        .sort('$TimePart', 'ascending')
+    }));
+
+    it('works with TIME split (timePart(MINUTE_OF_DAY)) (sort on split)', equalityTest({
+      executorNames: ['druid', 'mysql'],
+      expression: $('wiki').split($("time").timePart('MINUTE_OF_DAY'), 'TimePart')
+        .apply('TotalEdits', '$wiki.sum($count)')
+        .sort('$TimePart', 'ascending')
+        .limit(200)
     }));
 
     it('works with TIME split (timePart) (sort on apply)', equalityTest({

--- a/test/parser/plyqlParser.mocha.js
+++ b/test/parser/plyqlParser.mocha.js
@@ -64,6 +64,15 @@ describe("SQL parser", () => {
       expect(parse.expression.toJS()).to.deep.equal(ex2.toJS());
     });
 
+    it("works with a YEAR expression", () => {
+      var parse = Expression.parseSQL("YEAR(time)");
+
+      var ex2 = $('time').timePart('YEAR');
+
+      expect(parse.verb).to.equal(null);
+      expect(parse.expression.toJS()).to.deep.equal(ex2.toJS());
+    });
+
     it("works with a filtered SUM expression", () => {
       var parse = Expression.parseSQL("SUM(added WHERE cityName = 'San Francisco')");
 


### PR DESCRIPTION
- Dramatically reduced PlyQL parser size
- Added `YEAR` as a possible `timePart` value
- Added `CURDATE`, `PI`, `YEAR`, `MONTH`, `WEEK_OF_YEAR`, `DAY_OF_YEAR`, `DAY_OF_MONTH`,
  `DAY_OF_WEEK`, `HOUR`, `MINUTE`, `SECOND`, `DATE`, `CURRENT_TIMESTAMP`, `LOCALTIME`,
  `LOCALTIMESTAMP`, `UTC_TIMESTAMP`, `SYSDATE`, `CURRENT_DATE`, `UTC_DATE`, `DAY_OF_YEAR`,
  `DOY`, `DOW`, `DAYOFMONTH`, `DAY`, `WEEKOFYEAR`, and `WEEK` to PlyQL
- Fixed bug where `DAY_OF_YEAR`, `DAY_OF_MONTH`, and `DAY_OF_WEEK` was zero indexed