### PR TITLE
Fix Druid introspection bug on JS ingestion aggregators

### DIFF
--- a/.idea/dictionaries/vadim.xml
+++ b/.idea/dictionaries/vadim.xml
@@ -2,6 +2,7 @@
   <dictionary name="vadim">
     <words>
       <w>actionize</w>
+      <w>aggs</w>
       <w>amplab</w>
       <w>backtick</w>
       <w>curdate</w>

--- a/.idea/dictionaries/vadim.xml
+++ b/.idea/dictionaries/vadim.xml
@@ -4,6 +4,7 @@
       <w>actionize</w>
       <w>aggs</w>
       <w>amplab</w>
+      <w>attrs</w>
       <w>backtick</w>
       <w>curdate</w>
       <w>datas</w>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -9,5 +9,9 @@
     <inspection_tool class="JSUnfilteredForInLoop" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSUnresolvedFunction" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="JSUnresolvedVariable" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryLocalVariableJS" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+      <option name="m_ignoreAnnotatedVariables" value="false" />
+    </inspection_tool>
   </profile>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
 
+## 0.10.4
+
+- Fix Druid introspection bug on JS ingestion aggregators
+- Allow data-less PlyQL queries like `SELECT 1+1`
+- Default PlyQL `AS` text now matches SQL implementation.  
+
 ## 0.10.3
 
 - Removed duplicate entry that killed in strict mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
 
 ## 0.10.4
 
+- Made Dataset#apply and Dataset#select truly immutable
 - Fix Druid introspection bug on JS ingestion aggregators
 - Allow data-less PlyQL queries like `SELECT 1+1`
 - Default PlyQL `AS` text now matches SQL implementation.  

--- a/src/datatypes/dataset.ts
+++ b/src/datatypes/dataset.ts
@@ -422,18 +422,19 @@ module Plywood {
     }
 
     // Actions
-    public select(attributes: string[]): Dataset {
-      // Note this works in place, fix that later if needed.
-      var data = this.data;
+    public select(attrs: string[]): Dataset {
+      var value = this.valueOf();
+      var data = value.data;
       for (let datum of data) {
         for (let key in datum) {
-          if (attributes.indexOf(key) === -1) {
-            delete datum[key];
+          if (attrs.indexOf(key) === -1) {
+            delete datum[key]; // Note this works in place, fix that later if needed.
           }
         }
       }
-      this.attributes = null; // Since we did the change in place, blow out the attributes
-      return this;
+
+      value.attributes = value.attributes.filter((attribute) => attrs.indexOf(attribute.name) !== -1);
+      return new Dataset(value);
     }
 
     public apply(name: string, exFn: ComputeFn, type: PlyType, context: Datum): Dataset {

--- a/src/dialect/sqlDialect.ts
+++ b/src/dialect/sqlDialect.ts
@@ -34,10 +34,11 @@ module Plywood {
     public timeToSQL(date: Date): string {
       if (!date) return 'NULL';
       var str = date.toISOString()
-        .replace("T", " ")
-        .replace(/\.\d\d\dZ$/, "")
-        .replace(" 00:00:00", "");
-      return "'" + str + "'";
+        .replace('T', ' ')
+        .replace('Z', '')
+        .replace(/\.000$/, '')
+        .replace(/ 00:00:00$/, '');
+      return `TIMESTAMP('${str}')`;
     }
 
     public aggregateFilterIfNeeded(inputSQL: string, expressionSQL: string, zeroSQL: string = '0'): string {

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -138,7 +138,7 @@ module Plywood {
   export function $(name: string, nest?: number, type?: PlyType): RefExpression;
   export function $(name: string, type?: PlyType): RefExpression;
   export function $(name: string, nest?: any, type?: PlyType): RefExpression {
-    if (typeof name !== 'string') throw new TypeError('name must be a string');
+    if (typeof name !== 'string') throw new TypeError('$() argument must be a string');
     if (typeof nest === 'string') {
       type = nest;
       nest = 0;

--- a/src/expressions/chainExpression.ts
+++ b/src/expressions/chainExpression.ts
@@ -419,9 +419,12 @@ module Plywood {
         } else if (action instanceof LimitAction) {
           return dataset.limit(action.limit);
 
+        } else if (action instanceof SelectAction) {
+          return dataset.select(action.attributes);
+
         }
 
-        throw new Error(`could not execute ${action}`);
+        throw new Error(`could not execute action ${action}`);
       }
 
       var value = this.expression._computeResolvedSimulate(false, simulatedQueries);
@@ -458,9 +461,12 @@ module Plywood {
           } else if (action instanceof LimitAction) {
             return dataset.limit(action.limit);
 
+          } else if (action instanceof SelectAction) {
+            return dataset.select(action.attributes);
+
           }
 
-          throw new Error(`could not execute ${action}`);
+          throw new Error(`could not execute action ${action}`);
         }
       }
 

--- a/src/expressions/plyql.pegjs
+++ b/src/expressions/plyql.pegjs
@@ -394,8 +394,12 @@ Columns
 Column
   = ex:Expression as:As?
     {
+      if (as == null) {
+        as = text().trim();
+        if (as[0] === '`' && as[as.length - 1] === '`') as = as.substr(1, as.length - 2);
+      }
       return new ApplyAction({
-        name: as || text().replace(/^\W+|\W+$/g, '').replace(/\W+/g, '_'),
+        name: as,
         expression: ex
       });
     }

--- a/src/expressions/plyql.pegjs
+++ b/src/expressions/plyql.pegjs
@@ -193,14 +193,7 @@ function extractGroupByColumn(columns, groupBy, index) {
   };
 }
 
-function constructQuery(distinct, columns, from, where, groupBys, having, orderBy, limit) {
-  if (!columns) error('Can not have empty column list');
-  from = from ? $(from) : dataRef;
-
-  if (where) {
-    from = from.filter(where);
-  }
-
+function upgradeGroupBys(distinct, columns, groupBys) {
   if (Array.isArray(columns)) { // Not *
     if (!groupBys) {
       // Support for not having a group by clause if there are aggregates in the columns
@@ -212,13 +205,13 @@ function constructQuery(distinct, columns, from, where, groupBys, having, orderB
           columnExpression.actions.some(function(action) { return action.isAggregate(); })
       })
       if (hasAggregate) {
-        groupBys = [Expression.EMPTY_STRING];
+        return [Expression.EMPTY_STRING];
       } else if (distinct) {
-        groupBys = columns.map(function(column) { return column.expression });
+        return columns.map(function(column) { return column.expression });
       }
 
     } else {
-      groupBys = groupBys.map(function(groupBy) {
+      return groupBys.map(function(groupBy) {
         if (groupBy.isOp('literal') && groupBy.type === 'NUMBER') {
           // Support for not having a group by clause refer to a select column by index
 
@@ -233,39 +226,70 @@ function constructQuery(distinct, columns, from, where, groupBys, having, orderB
     }
   }
 
-  var query = null;
-  if (!groupBys) {
-    query = from;
+  return groupBys;
+}
 
-    if (Array.isArray(columns)) {
-      var attributes = [];
-      for (var i = 0; i < columns.length; i++) {
-        var column = columns[i];
-        query = query.performAction(column);
-        attributes.push(column.name);
-      }
-      query = query.select.apply(query, attributes);
+function staticColumn(column) {
+  return column.expression.getFreeReferences().length === 0;
+}
+
+function constructQuery(distinct, columns, from, where, groupBys, having, orderBy, limit) {
+  if (!columns) error('Can not have empty column list');
+
+  var query = null;
+
+  if (!distinct && Array.isArray(columns) && !from && !where && !groupBys && columns.every(staticColumn)) {
+    // This is a SELECT 1+1; type query
+    query = ply();
+    for (var i = 0; i < columns.length; i++) {
+      query = query.performAction(columns[i]);
     }
 
   } else {
-    if (columns === '*') error('can not SELECT * with a GROUP BY');
+    from = from ? $(from) : dataRef;
 
-    if (groupBys.length === 1 && groupBys[0].isOp('literal')) {
-      query = ply().apply('data', from);
-    } else {
-      var splits = {};
-      for (var i = 0; i < groupBys.length; i++) {
-        var groupBy = groupBys[i];
-        var extract = extractGroupByColumn(columns, groupBy, i);
-        columns = extract.otherColumns;
-        splits[extract.label] = groupBy;
-      }
-      query = from.split(splits, 'data');
+    if (where) {
+      from = from.filter(where);
     }
 
-    if (Array.isArray(columns)) {
-      for (var i = 0; i < columns.length; i++) {
-        query = query.performAction(columns[i]);
+    groupBys = upgradeGroupBys(distinct, columns, groupBys);
+
+
+    if (!groupBys) {
+      // Select query
+      query = from;
+
+      if (Array.isArray(columns)) {
+        var attributes = [];
+        for (var i = 0; i < columns.length; i++) {
+          var column = columns[i];
+          query = query.performAction(column);
+          attributes.push(column.name);
+        }
+        query = query.select.apply(query, attributes);
+      }
+
+    } else {
+      // Group By query
+      if (columns === '*') error('can not SELECT * with a GROUP BY');
+
+      if (groupBys.length === 1 && groupBys[0].isOp('literal')) {
+        query = ply().apply('data', from);
+      } else {
+        var splits = {};
+        for (var i = 0; i < groupBys.length; i++) {
+          var groupBy = groupBys[i];
+          var extract = extractGroupByColumn(columns, groupBy, i);
+          columns = extract.otherColumns;
+          splits[extract.label] = groupBy;
+        }
+        query = from.split(splits, 'data');
+      }
+
+      if (Array.isArray(columns)) {
+        for (var i = 0; i < columns.length; i++) {
+          query = query.performAction(columns[i]);
+        }
       }
     }
   }

--- a/test/overall/compute.mocha.js
+++ b/test/overall/compute.mocha.js
@@ -374,7 +374,7 @@ describe("compute native", () => {
       .done();
   });
 
-  it("works with select", (testComplete) => {
+  it("works with a basic select", (testComplete) => {
     var ds = Dataset.fromJS(data);
 
     var ex = ply(ds).select('price', 'cut');
@@ -388,6 +388,47 @@ describe("compute native", () => {
           { cut: 'Wow',   price: 160  },
           { cut: 'Wow',   price: 100  },
           { cut: null,    price: null }
+        ]);
+        testComplete();
+      })
+      .done();
+  });
+
+  it("works with a transformed select", (testComplete) => {
+    var ds = Dataset.fromJS(data);
+
+    var ex = ply(ds)
+      .apply('[cut]', '"[" ++ $cut ++ "]"')
+      .apply('price+1', '$price + 1')
+      .select('[cut]', 'price+1');
+
+    ex.compute()
+      .then((v) => {
+        expect(v.toJS()).to.deep.equal([
+          {
+            "[cut]": "[Good]",
+            "price+1": 401
+          },
+          {
+            "[cut]": "[Good]",
+            "price+1": 301
+          },
+          {
+            "[cut]": "[Great]",
+            "price+1": 125
+          },
+          {
+            "[cut]": "[Wow]",
+            "price+1": 161
+          },
+          {
+            "[cut]": "[Wow]",
+            "price+1": 101
+          },
+          {
+            "[cut]": null,
+            "price+1": 1
+          }
         ]);
         testComplete();
       })

--- a/test/parser/plyqlParser.mocha.js
+++ b/test/parser/plyqlParser.mocha.js
@@ -519,12 +519,12 @@ describe("SQL parser", () => {
 
     it("should parse a simple expression 2", () => {
       var parse = Expression.parseSQL(sane`
-        SELECT COUNT(page)
+        SELECT  COUNT(page)
       `);
 
       var ex2 = ply()
         .apply('data', '$data')
-        .apply('COUNT_page', '$data.filter($page.isnt(null)).count()');
+        .apply('COUNT(page)', '$data.filter($page.isnt(null)).count()');
 
       expect(parse.verb).to.equal('SELECT');
       expect(parse.table).to.equal(null);

--- a/test/parser/plyqlParser.mocha.js
+++ b/test/parser/plyqlParser.mocha.js
@@ -487,6 +487,20 @@ describe("SQL parser", () => {
       }).to.throw('Unmatched double quote on');
     });
 
+    it("should parse a trivial expression", () => {
+      var parse = Expression.parseSQL(sane`
+        SELECT 1+1 AS Two, 1+3 AS Three;
+      `);
+
+      var ex2 = ply()
+        .apply('Two', '1+1')
+        .apply('Three', '1+3');
+
+      expect(parse.verb).to.equal('SELECT');
+      expect(parse.table).to.equal(null);
+      expect(parse.expression.toJS()).to.deep.equal(ex2.toJS());
+    });
+
     it("should parse a simple expression", () => {
       var parse = Expression.parseSQL(sane`
         SELECT

--- a/test/simulate/amplabBenchmarkSQL.mocha.js
+++ b/test/simulate/amplabBenchmarkSQL.mocha.js
@@ -142,8 +142,8 @@ describe("simulate Druid for amplab benchmark", () => {
     var ex = Expression.parseSQL(sql).expression;
 
     expect(ex.toJS()).to.deep.equal(
-      $('uservisits').split('$sourceIP.substr(1, 5)', 'SUBSTR_sourceIP_1_5', 'data')
-        .apply('SUM_adRevenue', '$data.sum($adRevenue)')
+      $('uservisits').split('$sourceIP.substr(1, 5)', 'SUBSTR(sourceIP, 1, 5)', 'data')
+        .apply('SUM(adRevenue)', '$data.sum($adRevenue)')
         .toJS()
     );
 
@@ -152,7 +152,7 @@ describe("simulate Druid for amplab benchmark", () => {
         "aggregations": [
           {
             "fieldName": "adRevenue",
-            "name": "SUM_adRevenue",
+            "name": "SUM(adRevenue)",
             "type": "doubleSum"
           }
         ],
@@ -165,7 +165,7 @@ describe("simulate Druid for amplab benchmark", () => {
               "index": 1,
               "length": 5
             },
-            "outputName": "SUBSTR_sourceIP_1_5",
+            "outputName": "SUBSTR(sourceIP, 1, 5)",
             "type": "extraction"
           }
         ],
@@ -173,7 +173,7 @@ describe("simulate Druid for amplab benchmark", () => {
         "intervals": "1000-01-01/3000-01-01",
         "limitSpec": {
           "columns": [
-            "SUBSTR_sourceIP_1_5"
+            "SUBSTR(sourceIP, 1, 5)"
           ],
           "limit": 500000,
           "type": "default"

--- a/test/simulate/simulateMySQL.mocha.js
+++ b/test/simulate/simulateMySQL.mocha.js
@@ -105,7 +105,7 @@ describe("simulate MySQL", () => {
       FLOOR(\`carat\` / 0.25) * 0.25 AS "Carat",
       COALESCE(COUNT(*), 0) AS "Count"
       FROM \`diamonds\`
-      WHERE (((\`color\`<=>"D") AND (\`cut\`<=>"some_cut")) AND ('2015-03-13 07:00:00'<=\`time\` AND \`time\`<'2015-03-14 07:00:00'))
+      WHERE (((\`color\`<=>"D") AND (\`cut\`<=>"some_cut")) AND (TIMESTAMP('2015-03-13 07:00:00')<=\`time\` AND \`time\`<TIMESTAMP('2015-03-14 07:00:00')))
       GROUP BY 1
       ORDER BY \`Count\` DESC
       LIMIT 3


### PR DESCRIPTION
- Fix Druid introspection bug on JS ingestion aggregators
- Allow data-less PlyQL queries like `SELECT 1+1`
- Default PlyQL `AS` text now matches SQL implementation. 