### PR TITLE
get output types is two functions

### DIFF
--- a/src/actions/absoluteAction.ts
+++ b/src/actions/absoluteAction.ts
@@ -26,8 +26,12 @@ module Plywood {
       this._checkNoExpression();
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'NUMBER' as PlyType;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NUMBER');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/addAction.ts
+++ b/src/actions/addAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'NUMBER';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NUMBER');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/andAction.ts
+++ b/src/actions/andAction.ts
@@ -60,8 +60,12 @@ module Plywood {
       this._ensureAction("and");
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'BOOLEAN';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'BOOLEAN');
+      this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/applyAction.ts
+++ b/src/actions/applyAction.ts
@@ -44,8 +44,12 @@ module Plywood {
       return js;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'DATASET';
     }
 

--- a/src/actions/averageAction.ts
+++ b/src/actions/averageAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+ 
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/baseAction.ts
+++ b/src/actions/baseAction.ts
@@ -225,12 +225,15 @@ module Plywood {
       return false;
     }
 
-    protected _checkInputTypes(inputType: string, ...neededTypes: string[]) {
+    protected _checkInputTypes(inputType: PlyType) {
+      var neededTypes: PlyType | PlyType[] = this.getNecessaryInputTypes();
+
+      if (typeof neededTypes === 'string') neededTypes = [neededTypes as PlyType];
       if (inputType && inputType !== 'NULL' && neededTypes.indexOf(inputType) === -1) {
         if (neededTypes.length === 1) {
           throw new Error(`${this.action} must have input of type ${neededTypes[0]} (is ${inputType})`);
         } else {
-          throw new Error(`${this.action} must have input of type ${neededTypes.join(' or ')} (is ${inputType})`);
+          throw new Error(`${this.action} must have input of type ${(neededTypes as PlyType[]).join(' or ')} (is ${inputType})`);
         }
       }
     }
@@ -254,8 +257,11 @@ module Plywood {
 
     public abstract getOutputType(inputType: PlyType): PlyType
 
+    public abstract getNecessaryInputTypes(): PlyType | PlyType[]
+
+    protected _stringTransformInputType = ['STRING' as PlyType, 'SET/STRING' as PlyType];
     protected _stringTransformOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'STRING', 'SET/STRING');
+      this._checkInputTypes(inputType);
       return inputType;
     }
 

--- a/src/actions/cardinalityAction.ts
+++ b/src/actions/cardinalityAction.ts
@@ -26,8 +26,12 @@ module Plywood {
       this._checkNoExpression();
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return getAllSetTypes();
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'SET/STRING', 'SET/STRING_RANGE', 'SET/NUMBER', 'SET/NUMBER_RANGE', 'SET/TIME', 'SET/TIME_RANGE');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/castAction.ts
+++ b/src/actions/castAction.ts
@@ -101,14 +101,14 @@ module Plywood {
       return [this.outputType];
     }
 
-    public getOutputType(inputType: PlyType): PlyType {
-      var outputType = this.outputType;
-      if (inputType === outputType) return outputType;
-      if (inputType && (!CAST_TYPE_TO_FN[outputType][inputType]) && (!CAST_TYPE_TO_FN[outputType]['UNIVERSAL'])) {
-        throw new Error(`unsupported cast from ${inputType} to ${outputType}`);
-      }
+    public getNecessaryInputTypes(): PlyTypeSimple[] {
+      var castType = this.outputType;
+      var lookup = CAST_TYPE_TO_FN[castType] || CAST_TYPE_TO_FN[castType]['UNIVERSAL'];
+      return Object.keys(lookup) as PlyTypeSimple[];
+    }
 
-      return outputType;
+    public getOutputType(inputType: PlyType): PlyType {
+      return this.outputType;
     }
 
     public _fillRefSubstitutions(): FullType {

--- a/src/actions/castAction.ts
+++ b/src/actions/castAction.ts
@@ -103,8 +103,7 @@ module Plywood {
 
     public getNecessaryInputTypes(): PlyTypeSimple[] {
       var castType = this.outputType;
-      var lookup = CAST_TYPE_TO_FN[castType] || CAST_TYPE_TO_FN[castType]['UNIVERSAL'];
-      return Object.keys(lookup) as PlyTypeSimple[];
+      return Object.keys(CAST_TYPE_TO_FN[castType]) as PlyTypeSimple[];
     }
 
     public getOutputType(inputType: PlyType): PlyType {

--- a/src/actions/concatAction.ts
+++ b/src/actions/concatAction.ts
@@ -27,6 +27,10 @@ module Plywood {
       this._checkExpressionTypes('STRING');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this._stringTransformInputType;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
       return this._stringTransformOutputType(inputType);
     }

--- a/src/actions/containsAction.ts
+++ b/src/actions/containsAction.ts
@@ -62,8 +62,12 @@ module Plywood {
       return [expressionString, this.compare];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return ['STRING' as PlyType, 'SET/STRING' as PlyType];
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'STRING', 'SET/STRING');
+      this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/countAction.ts
+++ b/src/actions/countAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkNoExpression();
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/countDistinctAction.ts
+++ b/src/actions/countDistinctAction.ts
@@ -26,8 +26,12 @@ module Plywood {
       this._ensureAction("countDistinct");
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/customAction.ts
+++ b/src/actions/customAction.ts
@@ -51,8 +51,12 @@ module Plywood {
       return [this.custom]; // ToDo: escape this
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/customTransformAction.ts
+++ b/src/actions/customTransformAction.ts
@@ -34,6 +34,10 @@ module Plywood {
       this._ensureAction("customTransform");
     }
 
+    public getNecessaryInputTypes(): PlyType[] {
+      return ['NULL' as PlyTypeSimple, 'BOOLEAN' as PlyTypeSimple, 'NUMBER' as PlyTypeSimple, 'TIME' as PlyTypeSimple, 'STRING' as PlyTypeSimple]
+    }
+
     public valueOf(): ActionValue {
       var value = super.valueOf();
       value.custom = this.custom;
@@ -61,7 +65,7 @@ module Plywood {
     }
 
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NULL', 'BOOLEAN', 'NUMBER', 'TIME', 'STRING');
+      this._checkInputTypes(inputType);
       return this.outputType || inputType;
     }
 

--- a/src/actions/divideAction.ts
+++ b/src/actions/divideAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'NUMBER';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NUMBER');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/extractAction.ts
+++ b/src/actions/extractAction.ts
@@ -51,6 +51,10 @@ module Plywood {
       return [this.regexp];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this._stringTransformInputType;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
       return this._stringTransformOutputType(inputType);
     }

--- a/src/actions/fallbackAction.ts
+++ b/src/actions/fallbackAction.ts
@@ -25,9 +25,13 @@ module Plywood {
       this._ensureAction("fallback");
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this.expression.type;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
       var expressionType = this.expression.type;
-      if (expressionType && expressionType !== 'NULL') this._checkInputTypes(inputType, expressionType);
+      if (expressionType && expressionType !== 'NULL') this._checkInputTypes(inputType);
       return expressionType;
     }
 

--- a/src/actions/filterAction.ts
+++ b/src/actions/filterAction.ts
@@ -31,8 +31,12 @@ module Plywood {
       this._checkExpressionTypes('BOOLEAN');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'DATASET';
     }
 

--- a/src/actions/greaterThanAction.ts
+++ b/src/actions/greaterThanAction.ts
@@ -27,9 +27,13 @@ module Plywood {
       this._checkExpressionTypes('NUMBER', 'TIME', 'STRING');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this.expression.type;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.expression.type;
-      if (expressionType) this._checkInputTypes(inputType, expressionType);
+      var expressionType = this.getNecessaryInputTypes();
+      if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/greaterThanAction.ts
+++ b/src/actions/greaterThanAction.ts
@@ -32,7 +32,7 @@ module Plywood {
     }
 
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.getNecessaryInputTypes();
+      var expressionType = this.expression.type;
       if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }

--- a/src/actions/greaterThanOrEqualAction.ts
+++ b/src/actions/greaterThanOrEqualAction.ts
@@ -27,9 +27,13 @@ module Plywood {
       this._checkExpressionTypes('NUMBER', 'TIME', 'STRING');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this.expression.type;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.expression.type;
-      if (expressionType) this._checkInputTypes(inputType, expressionType);
+      var expressionType = this.getNecessaryInputTypes();
+      if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/greaterThanOrEqualAction.ts
+++ b/src/actions/greaterThanOrEqualAction.ts
@@ -32,7 +32,7 @@ module Plywood {
     }
 
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.getNecessaryInputTypes();
+      var expressionType = this.expression.type;
       if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }

--- a/src/actions/inAction.ts
+++ b/src/actions/inAction.ts
@@ -27,6 +27,10 @@ module Plywood {
       this._ensureAction("in");
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this.expression.type;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
       var expression = this.expression;
       if (inputType) {

--- a/src/actions/indexOfAction.ts
+++ b/src/actions/indexOfAction.ts
@@ -26,8 +26,12 @@ module Plywood {
       this._checkExpressionTypes('STRING');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'STRING';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'STRING');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/isAction.ts
+++ b/src/actions/isAction.ts
@@ -31,7 +31,7 @@ module Plywood {
     }
 
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.getNecessaryInputTypes();
+      var expressionType = this.expression.type;
       if (expressionType && expressionType !== 'NULL') this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }

--- a/src/actions/isAction.ts
+++ b/src/actions/isAction.ts
@@ -26,9 +26,13 @@ module Plywood {
       this._ensureAction("is");
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this.expression.type;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.expression.type;
-      if (expressionType && expressionType !== 'NULL') this._checkInputTypes(inputType, expressionType);
+      var expressionType = this.getNecessaryInputTypes();
+      if (expressionType && expressionType !== 'NULL') this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/joinAction.ts
+++ b/src/actions/joinAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       if(!this.expression.canHaveType('DATASET')) throw new TypeError('expression must be a DATASET');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'DATASET';
     }
 

--- a/src/actions/lengthAction.ts
+++ b/src/actions/lengthAction.ts
@@ -26,8 +26,12 @@ module Plywood {
       this._checkNoExpression();
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'STRING';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'STRING');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/lessThanAction.ts
+++ b/src/actions/lessThanAction.ts
@@ -27,9 +27,13 @@ module Plywood {
       this._checkExpressionTypes('NUMBER', 'TIME', 'STRING');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this.expression.type;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.expression.type;
-      if (expressionType) this._checkInputTypes(inputType, expressionType);
+      var expressionType = this.getNecessaryInputTypes();
+      if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/lessThanAction.ts
+++ b/src/actions/lessThanAction.ts
@@ -32,7 +32,7 @@ module Plywood {
     }
 
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.getNecessaryInputTypes();
+      var expressionType = this.expression.type;
       if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }

--- a/src/actions/lessThanOrEqualAction.ts
+++ b/src/actions/lessThanOrEqualAction.ts
@@ -27,9 +27,13 @@ module Plywood {
       this._checkExpressionTypes('NUMBER', 'TIME', 'STRING');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this.expression.type;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.expression.type;
-      if (expressionType) this._checkInputTypes(inputType, expressionType);
+      var expressionType = this.getNecessaryInputTypes();
+      if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/lessThanOrEqualAction.ts
+++ b/src/actions/lessThanOrEqualAction.ts
@@ -32,7 +32,7 @@ module Plywood {
     }
 
     public getOutputType(inputType: PlyType): PlyType {
-      var expressionType = this.getNecessaryInputTypes();
+      var expressionType = this.expression.type;
       if (expressionType) this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }

--- a/src/actions/limitAction.ts
+++ b/src/actions/limitAction.ts
@@ -54,8 +54,12 @@ module Plywood {
       return [String(this.limit)];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'DATASET';
     }
 

--- a/src/actions/lookupAction.ts
+++ b/src/actions/lookupAction.ts
@@ -51,6 +51,10 @@ module Plywood {
       return [String(this.lookup)];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this._stringTransformInputType;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
       return this._stringTransformOutputType(inputType);
     }

--- a/src/actions/matchAction.ts
+++ b/src/actions/matchAction.ts
@@ -81,8 +81,12 @@ module Plywood {
       return [this.regexp];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this._stringTransformInputType;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'STRING', 'SET/STRING');
+      this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/maxAction.ts
+++ b/src/actions/maxAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER', 'TIME');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/minAction.ts
+++ b/src/actions/minAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER', 'TIME');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/multiplyAction.ts
+++ b/src/actions/multiplyAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'NUMBER';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NUMBER');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/notAction.ts
+++ b/src/actions/notAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkNoExpression();
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'BOOLEAN';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'BOOLEAN');
+      this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/numberBucketAction.ts
+++ b/src/actions/numberBucketAction.ts
@@ -60,8 +60,12 @@ module Plywood {
       return params;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return ['NUMBER' as PlyType, 'NUMBER_RANGE' as PlyType];
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NUMBER', 'NUMBER_RANGE');
+      this._checkInputTypes(inputType);
       return 'NUMBER_RANGE';
     }
 

--- a/src/actions/orAction.ts
+++ b/src/actions/orAction.ts
@@ -51,8 +51,12 @@ module Plywood {
       this._ensureAction("or");
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'BOOLEAN';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'BOOLEAN');
+      this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/overlapAction.ts
+++ b/src/actions/overlapAction.ts
@@ -28,15 +28,25 @@ module Plywood {
       }
     }
 
-    public getOutputType(inputType: PlyType): PlyType {
+    public getNecessaryInputTypes(): PlyType[] {
       var expressionType = this.expression.type;
-      if (expressionType && expressionType !== 'NULL' && expressionType !== 'SET/NULL' && inputType && inputType !== 'NULL') {
-        var setInputType = wrapSetType(inputType);
+      if (expressionType && expressionType !== 'NULL' && expressionType !== 'SET/NULL') {
         var setExpressionType = wrapSetType(expressionType);
-        if (setInputType !== setExpressionType) {
-          throw new Error(`type mismatch in overlap action: ${inputType} is incompatible with ${expressionType}`);
-        }
+        var unwrapped = unwrapSetType(setExpressionType);
+        return [setExpressionType, unwrapped] as PlyType[];
+      } else {
+        // if it's null, accept anything
+        return [
+          'NULL', 'BOOLEAN', 'NUMBER', 'TIME', 'STRING', 'NUMBER_RANGE', 'TIME_RANGE', 'STRING_RANGE',
+          'SET', 'SET/NULL', 'SET/BOOLEAN', 'SET/NUMBER', 'SET/TIME', 'SET/STRING',
+          'SET/NUMBER_RANGE', 'SET/TIME_RANGE', 'DATASET'
+        ] as PlyType[];
       }
+
+    }
+
+    public getOutputType(inputType: PlyType): PlyType {
+      this._checkInputTypes(inputType);
       return 'BOOLEAN';
     }
 

--- a/src/actions/powerAction.ts
+++ b/src/actions/powerAction.ts
@@ -26,8 +26,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'NUMBER';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NUMBER');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/quantileAction.ts
+++ b/src/actions/quantileAction.ts
@@ -53,8 +53,12 @@ module Plywood {
       return [expressionString, String(this.quantile)];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/selectAction.ts
+++ b/src/actions/selectAction.ts
@@ -52,8 +52,12 @@ module Plywood {
       return this.attributes;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'DATASET';
     }
 

--- a/src/actions/sortAction.ts
+++ b/src/actions/sortAction.ts
@@ -62,8 +62,12 @@ module Plywood {
       return [expressionString, this.direction];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'DATASET';
     }
 

--- a/src/actions/splitAction.ts
+++ b/src/actions/splitAction.ts
@@ -90,8 +90,12 @@ module Plywood {
       }
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'DATASET';
     }
 

--- a/src/actions/substrAction.ts
+++ b/src/actions/substrAction.ts
@@ -58,6 +58,10 @@ module Plywood {
       return [String(this.position), String(this.length)];
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return this._stringTransformInputType;
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
       return this._stringTransformOutputType(inputType);
     }

--- a/src/actions/subtractAction.ts
+++ b/src/actions/subtractAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'NUMBER';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'NUMBER');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/sumAction.ts
+++ b/src/actions/sumAction.ts
@@ -27,8 +27,12 @@ module Plywood {
       this._checkExpressionTypes('NUMBER');
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'DATASET';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'DATASET');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/timeBucketAction.ts
+++ b/src/actions/timeBucketAction.ts
@@ -67,8 +67,12 @@ module Plywood {
       return ret;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return ['TIME' as PlyType, 'TIME_RANGE' as PlyType];
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'TIME', 'TIME_RANGE');
+      this._checkInputTypes(inputType);
       return 'TIME_RANGE';
     }
 

--- a/src/actions/timeFloorAction.ts
+++ b/src/actions/timeFloorAction.ts
@@ -66,8 +66,12 @@ module Plywood {
       return ret;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'TIME';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'TIME');
+      this._checkInputTypes(inputType);
       return 'TIME';
     }
 

--- a/src/actions/timePartAction.ts
+++ b/src/actions/timePartAction.ts
@@ -127,9 +127,12 @@ module Plywood {
       return ret;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'TIME';
+    }
 
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'TIME');
+      this._checkInputTypes(inputType);
       return 'NUMBER';
     }
 

--- a/src/actions/timeRangeAction.ts
+++ b/src/actions/timeRangeAction.ts
@@ -71,8 +71,12 @@ module Plywood {
       return ret;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'TIME';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'TIME');
+      this._checkInputTypes(inputType);
       return 'TIME_RANGE';
     }
 

--- a/src/actions/timeShiftAction.ts
+++ b/src/actions/timeShiftAction.ts
@@ -71,8 +71,12 @@ module Plywood {
       return ret;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'TIME';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'TIME');
+      this._checkInputTypes(inputType);
       return 'TIME';
     }
 

--- a/src/actions/transformCaseAction.ts
+++ b/src/actions/transformCaseAction.ts
@@ -55,8 +55,12 @@ module Plywood {
         this.transformType === other.transformType;
     }
 
+    public getNecessaryInputTypes(): PlyType | PlyType[] {
+      return 'STRING';
+    }
+
     public getOutputType(inputType: PlyType): PlyType {
-      this._checkInputTypes(inputType, 'STRING');
+      this._checkInputTypes(inputType);
       return 'STRING';
     }
 

--- a/src/datatypes/common.ts
+++ b/src/datatypes/common.ts
@@ -203,6 +203,17 @@ module Plywood {
     return isSetType(type) ? <PlyType>type.substr(4) : type;
   }
 
+  export function getAllSetTypes(): PlyTypeSimple[] {
+    return [
+      'SET/STRING' as PlyTypeSimple,
+      'SET/STRING_RANGE' as PlyTypeSimple,
+      'SET/NUMBER' as PlyTypeSimple,
+      'SET/NUMBER_RANGE' as PlyTypeSimple,
+      'SET/TIME' as PlyTypeSimple,
+      'SET/TIME_RANGE' as PlyTypeSimple
+    ];
+  }
+
   export interface SimpleFullType {
     type: PlyTypeSimple;
   }

--- a/src/expressions/chainExpression.ts
+++ b/src/expressions/chainExpression.ts
@@ -53,15 +53,8 @@ module Plywood {
         try {
           type = action.getOutputType(type);
         } catch (e) {
-          var pattern = e.message.match(/(?:\w+ must have input of type) ([A-Z_]+)/);
-          if (!pattern) {
-            pattern =  e.message.match(/(?:\w+ has a bad type combination) ([A-Z_]+) IN ([A-Z_]+)/);
-            if (!pattern) throw e;
-            type = pattern[2];
-          }
-
-          var neededType = pattern[1];
-
+          var neededType: PlyType = action.getNecessaryInputTypes() as PlyType;
+          // todo: neededType could be more than 1 value, just so happens that with current tests cases neededType always returns one value
           if (i === 0) {
               expression = expression.upgradeToType(neededType);
               type = expression.type;

--- a/test/actions/action.mocha.js
+++ b/test/actions/action.mocha.js
@@ -87,6 +87,7 @@ describe("Action", () => {
       { action: 'customTransform', custom: 'decodeURIComponentToLowerCaseAndTrim' },
       { action: 'customTransform', custom: 'includes', outputType: 'BOOLEAN' },
 
+      { action: 'concat', expression: { op: 'literal', value: 'myVar' } },
 
       { action: 'contains', expression: { op: 'ref', name: 'myVar' }, compare: 'normal' },
       { action: 'contains', expression: { op: 'ref', name: 'myVar' }, compare: 'ignoreCase' },

--- a/test/overall/typecheck.mocha.js
+++ b/test/overall/typecheck.mocha.js
@@ -78,6 +78,6 @@ describe("typecheck", () => {
   it("should throw on overlay type mismatch", () => {
     expect(() => {
       $('x', 'NUMBER').overlap($('y', 'SET/STRING'));
-    }).to.throw('type mismatch in overlap action: NUMBER is incompatible with SET/STRING');
+    }).to.throw('overlap must have input of type SET/STRING or STRING (is NUMBER)');
   });
 });


### PR DESCRIPTION
Right now chain expression figures out what/when it needs to upgrade an expression or action type by parsing an error message.  Also, currently the public getOutputType function does the job of both validating input type (which also happens to return the desired input type and is protected) and getting output type.  This PR makes the get input type part public and return the type instead of just validating it and throwing, so chain expression can call it.