### PR TITLE
better API for dataset functions

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,14 +3,4 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
 
+## 0.15.1
+
+- All Dataset computation and aggregation functions now take expressions instead of functions.
+  Each has a corresponding function that takes a function like the old API.
+  So `Dataset#apply(name, x)` now expects `x` to be and expression but `Dataset#applyFn(name, x)` has the old API
+- `AttributeInfo#type` defaults to `STRING`
+- Removed PlyQL parser from plywood-lite
+
+
 ## 0.14.12
 
 - Druid countDistinct planing no longer does `byRow: true` to be more inline with how plywood aggregates work in general
@@ -54,8 +63,8 @@ For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
 - Totally reworked internal representation all BlahAction classes are now BlahExpression
 - removed `.custom` use `.customAggregate`
 - changed `lookup` to `lookupFn`
-- changed `LimitAction#limit` to `LimitExpression#value` 
-- changed `QuantileAction#quantile` to `QuantileExpression#value` 
+- changed `LimitAction#limit` to `LimitExpression#value`
+- changed `QuantileAction#quantile` to `QuantileExpression#value`
 - Fixed NOT() in Druid having clause
 - removed `Expression#actionize`
 - removed `Expression#firstAction`

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@ Plywood is architected around the principles of nested
 [Split-Apply-Combine](http://www.jstatsoft.org/article/view/v040i01/v40i01.pdf),
 a powerful divide-and-conquer algorithm that can be used to construct all types
 of data visualizations. Plywood comes with its own [expression
-language](docs/expressions.md) where a single Plywood expression can
+language](expressions.md) where a single Plywood expression can
 translate to multiple database queries, and where results are returned in a
 nested data structure so they can be easily consumed by visualization libraries
-such as [D3.js](http://d3js.org/). 
+such as [D3.js](http://d3js.org/).
 
 You can use Plywood in the browser and/or in node.js to easily create your own
 visualizations and applications. For an example application built using
@@ -21,13 +21,13 @@ Plywood also acts as a very advanced query planner for Druid, and Plywood will
 determine the most optimal way to execute Druid queries.
 
 ## Should you use Plywood?
- 
+
 Here are some possible usage scenarios for Plywood:
 
 ### You are building a web-based, data-driven application, node.js backend
- 
+
 Plywood primitives can serve as the 'models' for the web application.
-The frontend can send JSON serialized Plywood queries to the backend. 
+The frontend can send JSON serialized Plywood queries to the backend.
 The backend uses Plywood to translate Plywood queries to database queries as well as doing permission management and access control by utilizing Plywood heleprs.
 
 ![web app, node.js](images/web-app-nodejs.png)
@@ -49,11 +49,11 @@ It might be undesirable to have the web app communicate with the DB directly in 
 If JavaScript does not fit into your stack you can still benefit from Plywood by utilizing plyql.
 Your application could ether generate Plywood queries in their JSON form or as PlyQL SQL strings that it sends over to plyql running in server mode.
 plyql will send back nested JSON results.
-   
+
 ![app, proxy](images/app-proxy.png)
-   
-### You know SQL and want to query a DB that does not use SQL (like Druid)   
-   
+
+### You know SQL and want to query a DB that does not use SQL (like Druid)
+
 Maybe all you want is to have a SQL-like interface to Druid. You can use the [plyql](https://github.com/implydata/plyql) command line utility to talk to Druid.
 
 ![plyql](images/plyql.png)
@@ -119,7 +119,7 @@ var druidRequesterFactory = require('plywood-druid-requester').druidRequesterFac
 ```
 
 * External: An external acts as a query planner and scheduler for its database. [More about them here](./design-overview.md)
-* DruidRequesterFactory: This is a node specific module. Each external requires a requester function and this module exposes a factory function that makes these requester functions. 
+* DruidRequesterFactory: This is a node specific module. Each external requires a requester function and this module exposes a factory function that makes these requester functions.
 
 Next, the druid connection needs to be configured:
 
@@ -129,7 +129,7 @@ var druidRequester = druidRequesterFactory({
 });
 ```
 
-Construct an external from a JSON definition. 
+Construct an external from a JSON definition.
 
 ```javascript
 var wikiDataset = External.fromJS({
@@ -137,14 +137,14 @@ var wikiDataset = External.fromJS({
   source: 'wikipedia',  // The datasource name in Druid
   timeAttribute: 'time',  // Druid's anonymous time attribute will be called 'time',
   context: {
-    timeout: 10000 // The Druid context 
+    timeout: 10000 // The Druid context
   }
 }, druidRequester);
 ```
 
-Once that is up and running, we should configure our execution context 
+Once that is up and running, we should configure our execution context
 (Note, this is unrelated to the Druid context defined in the external)
-The execution context is a map that allows us to define values that our query can refer to.  
+The execution context is a map that allows us to define values that our query can refer to.
 With the following context definition, we can now refer to our wikipedia External as "wiki".
 Less helpfully, we can also refer to the number 70 with the string "seventy".
 
@@ -172,7 +172,7 @@ var ex = ply()
 
   // Calculate the sum of the `added` attribute
   .apply('TotalAdded', '$wiki.sum($added)');
-  
+
   // Refer to the seventy defined in the context
   .apply('70', $('seventy'));
 

--- a/extra/postfix-lite.js
+++ b/extra/postfix-lite.js
@@ -1,0 +1,1 @@
+Expression.expressionParser = require("./expressionParser")(exports, Chronoshift);

--- a/rrollup
+++ b/rrollup
@@ -177,7 +177,7 @@ cat \
   \
   build/external/baseExternal.js \
   build/executor/basicExecutor.js \
-  extra/postfix.js \
+  extra/postfix-lite.js \
   | ./node_modules/.bin/f 'l.replace(/^import .*$/, "")' \
   | ./node_modules/.bin/f 'l.replace(/^export function ([\w$]+)\(/, "var $1 = exports.$1 = function(")' \
   | ./node_modules/.bin/f 'l.replace(/^export var ([\w$]+) =/, "var $1 = exports.$1 =")' \

--- a/src/datatypes/attributeInfo.ts
+++ b/src/datatypes/attributeInfo.ts
@@ -136,11 +136,8 @@ export class AttributeInfo implements Instance<AttributeInfoValue, AttributeInfo
       throw new Error("name must be a string");
     }
     this.name = parameters.name;
-
-    if (parameters.type) {
-      if (!RefExpression.validType(parameters.type)) throw new Error(`invalid type: ${parameters.type}`);
-      this.type = parameters.type;
-    }
+    this.type = parameters.type || 'STRING';
+    if (!RefExpression.validType(this.type)) throw new Error(`invalid type: ${this.type}`);
 
     this.datasetType = parameters.datasetType;
     this.unsplitable = Boolean(parameters.unsplitable);
@@ -154,16 +151,6 @@ export class AttributeInfo implements Instance<AttributeInfoValue, AttributeInfo
     }
     if (this.special !== special) {
       throw new TypeError(`incorrect attributeInfo special '${this.special}' (needs to be: '${special}')`);
-    }
-  }
-
-  public _ensureType(myType: PlyType) {
-    if (!this.type) {
-      this.type = myType;
-      return;
-    }
-    if (this.type !== myType) {
-      throw new TypeError(`incorrect attributeInfo type '${this.type}' (needs to be: '${myType}')`);
     }
   }
 
@@ -245,7 +232,7 @@ export class UniqueAttributeInfo extends AttributeInfo {
   constructor(parameters: AttributeInfoValue) {
     super(parameters);
     this._ensureSpecial("unique");
-    this._ensureType('STRING');
+    this.type = 'STRING';
   }
 
   public serialize(value: any): string {
@@ -268,7 +255,7 @@ export class ThetaAttributeInfo extends AttributeInfo {
   constructor(parameters: AttributeInfoValue) {
     super(parameters);
     this._ensureSpecial("theta");
-    this._ensureType('STRING');
+    this.type = 'STRING';
   }
 
   public serialize(value: any): string {
@@ -291,7 +278,7 @@ export class HistogramAttributeInfo extends AttributeInfo {
   constructor(parameters: AttributeInfoValue) {
     super(parameters);
     this._ensureSpecial("histogram");
-    this._ensureType('NUMBER');
+    this.type = 'NUMBER';
   }
 
   public serialize(value: any): string {

--- a/src/expressions/applyExpression.ts
+++ b/src/expressions/applyExpression.ts
@@ -86,7 +86,7 @@ export class ApplyExpression extends ChainableUnaryExpression {
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
     if (!operandValue) return null;
     const { name, expression } = this;
-    return (operandValue as Dataset).apply(name, expression.getFn(), expression.type);
+    return (operandValue as Dataset).apply(name, expression);
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {
@@ -119,6 +119,7 @@ export class ApplyExpression extends ChainableUnaryExpression {
       return this.swapWithOperand();
     }
 
+    // r(Dataset).apply(...)
     let dataset = operand.getLiteralValue();
     if (dataset instanceof Dataset && expression.resolved()) {
       // Omg mega hack:
@@ -129,7 +130,7 @@ export class ApplyExpression extends ChainableUnaryExpression {
         return this;
       }
 
-      dataset = dataset.apply(name, (d: Datum): any => {
+      dataset = dataset.applyFn(name, (d: Datum): any => {
         let simp = expression.resolve(d).simplify();
         if (simp instanceof ExternalExpression) return simp.external;
         if (simp instanceof LiteralExpression) return simp.value;

--- a/src/expressions/averageExpression.ts
+++ b/src/expressions/averageExpression.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import { r, ExpressionJS, ExpressionValue, Expression, ChainableUnaryExpression } from './baseExpression';
 import { Aggregate } from './mixins/aggregate';
 import { SQLDialect } from '../dialect/baseDialect';
@@ -35,9 +34,7 @@ export class AverageExpression extends ChainableUnaryExpression implements Aggre
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    if (!operandValue) return null;
-    const { expression } = this;
-    return (operandValue as Dataset).average(expression.getFn());
+    return operandValue ? (operandValue as Dataset).average(this.expression) : null;
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {

--- a/src/expressions/collectExpression.ts
+++ b/src/expressions/collectExpression.ts
@@ -34,7 +34,7 @@ export class CollectExpression extends ChainableUnaryExpression implements Aggre
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? (operandValue as Dataset).collect(this.expression.getFn()) : null;
+    return operandValue ? (operandValue as Dataset).collect(this.expression) : null;
   }
 
 }

--- a/src/expressions/countDistinctExpression.ts
+++ b/src/expressions/countDistinctExpression.ts
@@ -33,7 +33,7 @@ export class CountDistinctExpression extends ChainableUnaryExpression implements
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? (operandValue as Dataset).countDistinct(this.expression.getFn()) : null;
+    return operandValue ? (operandValue as Dataset).countDistinct(this.expression) : null;
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {

--- a/src/expressions/filterExpression.ts
+++ b/src/expressions/filterExpression.ts
@@ -39,7 +39,7 @@ export class FilterExpression extends ChainableUnaryExpression {
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? (operandValue as Dataset).filter(this.expression.getFn()) : null;
+    return operandValue ? (operandValue as Dataset).filter(this.expression) : null;
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {

--- a/src/expressions/maxExpression.ts
+++ b/src/expressions/maxExpression.ts
@@ -34,7 +34,7 @@ export class MaxExpression extends ChainableUnaryExpression implements Aggregate
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? (operandValue as Dataset).max(this.expression.getFn()) : null;
+    return operandValue ? (operandValue as Dataset).max(this.expression) : null;
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {

--- a/src/expressions/minExpression.ts
+++ b/src/expressions/minExpression.ts
@@ -34,7 +34,7 @@ export class MinExpression extends ChainableUnaryExpression implements Aggregate
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? (operandValue as Dataset).min(this.expression.getFn()) : null;
+    return operandValue ? (operandValue as Dataset).min(this.expression) : null;
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {

--- a/src/expressions/quantileExpression.ts
+++ b/src/expressions/quantileExpression.ts
@@ -16,7 +16,7 @@
 
 import { r, ExpressionJS, ExpressionValue, Expression, ChainableUnaryExpression } from './baseExpression';
 import { Aggregate } from './mixins/aggregate';
-import { PlywoodValue } from '../datatypes/index';
+import { PlywoodValue, Dataset } from '../datatypes/index';
 
 export class QuantileExpression extends ChainableUnaryExpression implements Aggregate {
   static op = "Quantile";
@@ -59,18 +59,8 @@ export class QuantileExpression extends ChainableUnaryExpression implements Aggr
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? operandValue.quantile(this.expression.getFn(), this.value) : null;
+    return operandValue ? (operandValue as Dataset).quantile(this.expression, this.value) : null;
   }
-
-  // protected _performOnLiteral(literalExpression: LiteralExpression): Expression {
-  //   const { expression, quantile } = this;
-  //   if (literalExpression.value === null) return Expression.NULL;
-  //   let dataset = literalExpression.value;
-  //
-  //   dataset = dataset.quantile(expression.getFn(), quantile);
-  //
-  //   return r(dataset);
-  // }
 }
 
 Expression.applyMixins(QuantileExpression, [Aggregate]);

--- a/src/expressions/sortExpression.ts
+++ b/src/expressions/sortExpression.ts
@@ -16,7 +16,7 @@
 
 import { r, ExpressionJS, ExpressionValue, Expression, ChainableUnaryExpression } from './baseExpression';
 import { SQLDialect } from '../dialect/baseDialect';
-import { PlywoodValue } from '../datatypes/index';
+import { PlywoodValue, Dataset } from '../datatypes/index';
 import { RefExpression } from './refExpression';
 
 export type Direction = 'ascending' | 'descending';
@@ -75,7 +75,7 @@ export class SortExpression extends ChainableUnaryExpression {
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? operandValue.sort(this.expression.getFn(), this.direction) : null;
+    return operandValue ? (operandValue as Dataset).sort(this.expression, this.direction) : null;
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {

--- a/src/expressions/splitExpression.ts
+++ b/src/expressions/splitExpression.ts
@@ -165,10 +165,9 @@ export class SplitExpression extends ChainableExpression implements Aggregate {
   }
 
   public calc(datum: Datum): PlywoodValue {
-    let { operand, dataName } = this;
-    let splitFns = this.mapSplitExpressions((ex) => ex.getFn());
+    let { operand, splits, dataName } = this;
     const operandValue = operand.calc(datum);
-    return operandValue ? (operandValue as Dataset).split(splitFns, dataName) : null;
+    return operandValue ? (operandValue as Dataset).split(splits, dataName) : null;
   }
 
   public getSQL(dialect: SQLDialect): string {

--- a/src/expressions/sumExpression.ts
+++ b/src/expressions/sumExpression.ts
@@ -38,7 +38,7 @@ export class SumExpression extends ChainableUnaryExpression implements Aggregate
   }
 
   protected _calcChainableUnaryHelper(operandValue: any, expressionValue: any): PlywoodValue {
-    return operandValue ? (operandValue as Dataset).sum(this.expression.getFn()) : null;
+    return operandValue ? (operandValue as Dataset).sum(this.expression) : null;
   }
 
   protected _getSQLChainableUnaryHelper(dialect: SQLDialect, operandSQL: string, expressionSQL: string): string {

--- a/src/external/baseExternal.ts
+++ b/src/external/baseExternal.ts
@@ -1292,7 +1292,7 @@ export abstract class External {
   public addNextExternal(dataset: Dataset): Dataset {
     const { mode, dataName, split } = this;
     if (mode !== 'split') throw new Error('must be in split mode to addNextExternal');
-    return dataset.apply(dataName, (d: Datum) => {
+    return dataset.applyFn(dataName, (d: Datum) => {
       return this.getRaw()._addFilterExpression(Expression._.filter(split.filterFromDatum(d)));
     }, 'DATASET');
   }


### PR DESCRIPTION
- All Dataset computation and aggregation functions now take expressions instead of functions.
  Each has a corresponding function that takes a function like the old API.
  So `Dataset#apply(name, x)` now expects `x` to be and expression but `Dataset#applyFn(name, x)` has the old API
- `AttributeInfo#type` defaults to `STRING`
- Removed PlyQL parser from plywood-lite