### PR TITLE
time format should include timezone infomation because druid format d…

### DIFF
--- a/src/external/utils/druidExtractionFnBuilder.ts
+++ b/src/external/utils/druidExtractionFnBuilder.ts
@@ -85,8 +85,8 @@ export class DruidExtractionFnBuilder {
   static SPAN_TO_FLOOR_FORMAT: Lookup<string> = {
     second: "yyyy-MM-dd'T'HH:mm:ss'Z",
     minute: "yyyy-MM-dd'T'HH:mm'Z",
-    hour: "yyyy-MM-dd'T'HH':00Z",
-    day: "yyyy-MM-dd'Z",
+    hour: "yyyy-MM-dd'T'HH':00:00'Z",
+    day: "yyyy-MM-dd'T00:00:00'Z",
     month: "yyyy-MM'-01Z",
     year: "yyyy'-01-01Z"
   };


### PR DESCRIPTION
This pull request is to fix issue #127.

Allow me to repeat the context of the issue. When we apply two splits, one on timeBucket, other on usual column. Plywood will generate groupBy request with the timeformat like following :

```
"queryType":"groupBy",
"granularity":"all",
"dimensions":[
    {"type":"default","dimension":"ad","outputName":"ad"},
    {"type":"extraction","dimension":"__time","outputName":"hour","extractionFn":
            {"format":"yyyy-MM-dd'Z","timeZone":"Europe/Paris","type":"timeFormat"}
    }
]
```

Druid will return the formatted date with on the specific timezone, the formatted date will be use in the time range where the non UTC formatted date will be used as UTC date. 

```
druidExternal.timeRangeInflaterFactory(label: string, duration: Duration, timezone: Timezone): Inflater {
      return (d: any) => {
        var v = d[label];
        if ('' + v === "null") {
          d[label] = null;
          return;
        }

        var start = new Date(v); // new Date will use the timezone of client instead of input timezone   
        d[label] = new TimeRange({ start, end: duration.shift(start, timezone) })
      };
    }
```

So the solution of the pull request is to change the date format to return a parsable date format with timezone like this `2017-01-01T00:00:00+02:00`

