### PR TITLE
Added general error for an expression used in the wrong context

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -23,9 +23,6 @@
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
       <option name="IMPORT_SORT_MODULE_NAME" value="true" />
     </TypeScriptCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <codeStyleSettings language="CSS">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,6 +3,7 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="CssInvalidHtmlTagReference" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CssInvalidPseudoSelector" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JSClosureCompilerSyntax" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSJQueryEfficiency" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSMethodCanBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <files-pattern value="{**/*,*}.{js,ts,jsx,tsx,css,scss}" />
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/src/external/utils/druidExtractionFnBuilder.ts
+++ b/src/external/utils/druidExtractionFnBuilder.ts
@@ -485,12 +485,7 @@ export class DruidExtractionFnBuilder {
     try {
       jsExtractionFn['function'] = ex.getJSFn('d');
     } catch (e) {
-      if (ex instanceof ChainableUnaryExpression) {
-        prefixFn = this.expressionToExtractionFnPure(ex.operand);
-        jsExtractionFn['function'] = ex.getAction().getJSFn('d');
-      } else {
-        throw e;
-      }
+      throw new Error('This expression is used in the wrong context');
     }
 
     if (ex.isOp('concat')) jsExtractionFn.injective = true;


### PR DESCRIPTION
**Purpose**
To fix uninformative error being returned when a expression is improperly constructed.

**Key Changes**
Plywood will now throw a single informative error when an expression is incorrect. Also, updated WebStorm settings to automatically run ESLint on save.
