### PR TITLE
Fix tslib prefix

### DIFF
--- a/extra/prefix.js
+++ b/extra/prefix.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tslib_1 = require('tslib');
+var { __extends } = require('tslib');
 
 var hasOwnProp = require('has-own-prop');
 var toArray = require('stream-to-array');


### PR DESCRIPTION
Upgrading TypeScript necessitated a tslib upgrade and now they use ES exports.