### PR TITLE
Bump immutable-class and chronoshift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -636,34 +636,13 @@
       "dev": true
     },
     "chronoshift": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/chronoshift/-/chronoshift-0.9.6.tgz",
-      "integrity": "sha512-0WMvtRqVgwTP7JGXVcerMDSQ7FlrS56jAEtAGxUg8k/pa3WqKFs9ZJUWIPkLxUzPNdb1holpzbqHmZiI6l+3Nw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/chronoshift/-/chronoshift-0.10.0.tgz",
+      "integrity": "sha512-dNvumPg7R6ACUOKbGo1zH6DtmTo5ut9/LNbzqaKGnpC9VdArIos8+kApHOVIZH4FCpm9M9XYh++jwlRHhc1PyA==",
       "requires": {
-        "immutable-class": "^0.9.4",
+        "immutable-class": "^0.11.0",
         "moment-timezone": "^0.5.26",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "has-own-prop": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
-          "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
-        },
-        "immutable-class": {
-          "version": "0.9.10",
-          "resolved": "https://registry.npmjs.org/immutable-class/-/immutable-class-0.9.10.tgz",
-          "integrity": "sha512-50oi0jta4/iQkOEgnDlcVaw8vqRLtPmAkvMQBfS1yPNs9KUEOeSGYqokARcvGX2DFv/sZRuBC7oBN+Bf/jNolw==",
-          "requires": {
-            "has-own-prop": "^2.0.0",
-            "tslib": "^1.10.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.3.1"
       }
     },
     "ci-info": {
@@ -2174,23 +2153,18 @@
       "dev": true
     },
     "immutable-class": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/immutable-class/-/immutable-class-0.10.0.tgz",
-      "integrity": "sha512-1dLkIy6PDofK9lUHScJaOMx4Fq905AQUaTu7ndmRzOV+S/DjXZvgrymkM3cS0aLZZTXJ82pixmBvGyN+5zOdQg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/immutable-class/-/immutable-class-0.11.1.tgz",
+      "integrity": "sha512-8uW0QQUDNUfTXDVmkOC/y0e11JdJdThREFujeVpHGtiNX8PoufaQpLfucw1VN6NRGgr2b+uZ8n/GnPW5mpqUaQ==",
       "requires": {
         "has-own-prop": "^2.0.0",
-        "tslib": "^1.10.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "has-own-prop": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
           "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "node": "12.22.10"
   },
   "dependencies": {
-    "chronoshift": "^0.9.0",
+    "chronoshift": "^0.10.0",
     "druid-query-toolkit": "^0.14.10",
     "druid.d.ts": "^0.12.1",
     "has-own-prop": "^1.0.1",
-    "immutable-class": "^0.10.0",
+    "immutable-class": "^0.11.1",
     "moment-timezone": "^0.5.26",
     "plywood-base-api": "^0.2.8",
     "readable-stream": "^3.0.3",


### PR DESCRIPTION
Targets the latest versions of immutable-class and chronoshift. No functional changes since Plywood does not use BaseImmutable and is therefore not affected by `useDefineForClassFields`.