### PR TITLE
Add support for MV_FILTER_ONLY in druidsql

### DIFF
--- a/extra/prefix.js
+++ b/extra/prefix.js
@@ -12,6 +12,7 @@ var Transform = readableStream.Transform;
 var PassThrough = readableStream.PassThrough;
 
 var immutableClass = require('immutable-class');
+var generalArraysEqual = immutableClass.generalArraysEqual;
 var generalEqual = immutableClass.generalEqual;
 var generalLookupsEqual = immutableClass.generalLookupsEqual;
 var isImmutableClass = immutableClass.isImmutableClass;

--- a/rrollup
+++ b/rrollup
@@ -71,6 +71,7 @@ cat \
   build/expressions/minExpression.js \
   build/expressions/multiplyExpression.js \
   build/expressions/mvContainsExpression.js \
+  build/expressions/mvFilterOnlyExpression.js \
   build/expressions/mvOverlapExpression.js \
   build/expressions/notExpression.js \
   build/expressions/numberBucketExpression.js \

--- a/src/dialect/baseDialect.ts
+++ b/src/dialect/baseDialect.ts
@@ -122,6 +122,10 @@ export abstract class SQLDialect {
     throw new Error('must implement');
   }
 
+  public mvFilterOnlyExpression(_a: string, _b: string[]): string {
+    throw new Error('must implement');
+  }
+
   public mvOverlapExpression(_a: string, _b: string): string {
     throw new Error('must implement');
   }

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -109,8 +109,9 @@ export class DruidDialect extends SQLDialect {
     return `TIMESTAMP '${this.dateToSQLDateString(date)}'`;
   }
 
-  public stringSetToSQL(value: Set): string {
-    const arr = value.elements.map((v: string) => this.escapeLiteral(v));
+  public stringSetToSQL(valueOrElements: Set | string[]): string {
+    const elements = Array.isArray(valueOrElements) ? valueOrElements : valueOrElements.elements;
+    const arr = elements.map((v: string) => this.escapeLiteral(v));
     return `ARRAY[${arr.join(',')}]`;
   }
 

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -127,6 +127,10 @@ export class DruidDialect extends SQLDialect {
     return `MV_CONTAINS(${a},${b})`;
   }
 
+  public mvFilterOnlyExpression(a: string, b: string[]): string {
+    return `MV_FILTER_ONLY(${a},${this.stringSetToSQL(b)})`;
+  }
+
   public mvOverlapExpression(a: string, b: string): string {
     return `MV_OVERLAP(${a},${b})`;
   }

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -84,6 +84,7 @@ import { MaxExpression } from './maxExpression';
 import { MinExpression } from './minExpression';
 import { MultiplyExpression } from './multiplyExpression';
 import { MvContainsExpression } from './mvContainsExpression';
+import { MvFilterOnlyExpression } from './mvFilterOnlyExpression';
 import { MvOverlapExpression } from './mvOverlapExpression';
 import { NotExpression } from './notExpression';
 import { NumberBucketExpression } from './numberBucketExpression';
@@ -243,6 +244,7 @@ export interface ExpressionValue {
   outputType?: PlyTypeSimple;
   tuning?: string;
   sql?: string;
+  mvArray?: string[];
 }
 
 export interface ExpressionJS {
@@ -279,6 +281,7 @@ export interface ExpressionJS {
   outputType?: PlyTypeSimple;
   tuning?: string;
   sql?: string;
+  mvArray?: string[];
 }
 
 export interface ExtractAndRest {
@@ -1219,6 +1222,10 @@ export abstract class Expression implements Instance<ExpressionValue, Expression
   public mvContains(ex: any) {
     if (!(ex instanceof Expression)) ex = Expression.fromJSLoose(ex);
     return new MvContainsExpression({ operand: this, expression: ex });
+  }
+
+  public mvFilterOnly(mvArray: string[]) {
+    return new MvFilterOnlyExpression({ operand: this, mvArray });
   }
 
   public mvOverlap(ex: any) {

--- a/src/expressions/mvFilterOnlyExpression.ts
+++ b/src/expressions/mvFilterOnlyExpression.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016-2022 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generalArraysEqual } from 'immutable-class';
+
+import { SQLDialect } from '../dialect/baseDialect';
+
+import { ChainableExpression, Expression, ExpressionJS, ExpressionValue } from './baseExpression';
+
+export class MvFilterOnlyExpression extends ChainableExpression {
+  static op = 'MvFilterOnly';
+  static fromJS(parameters: ExpressionJS): MvFilterOnlyExpression {
+    const value = ChainableExpression.jsToValue(parameters);
+    value.mvArray = parameters.mvArray;
+    return new MvFilterOnlyExpression(value);
+  }
+
+  public mvArray: string[];
+
+  constructor(parameters: ExpressionValue) {
+    super(parameters, dummyObject);
+    this._ensureOp('mvFilterOnly');
+    this._checkOperandTypes('STRING');
+    this.mvArray = parameters.mvArray;
+    this.type = 'STRING';
+  }
+
+  public valueOf(): ExpressionValue {
+    const value = super.valueOf();
+    value.mvArray = this.mvArray;
+    return value;
+  }
+
+  public toJS(): ExpressionJS {
+    const js = super.toJS();
+    js.mvArray = this.mvArray;
+    return js;
+  }
+
+  public equals(other: MvFilterOnlyExpression | undefined): boolean {
+    return super.equals(other) && generalArraysEqual(this.mvArray, other.mvArray);
+  }
+
+  protected _toStringParameters(_indent?: int): string[] {
+    return this.mvArray;
+  }
+
+  protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {
+    return dialect.mvFilterOnlyExpression(operandSQL, this.mvArray);
+  }
+}
+
+Expression.register(MvFilterOnlyExpression);


### PR DESCRIPTION
Adds `mvFilterOnly` expression, which is only supported in druidsql. Purposely undocumented because it is only added to support Pivot features.