### PR TITLE
[IMPLY-23543] Added IpSearchExpression and IpMatchExpression to support ip_search and ip_match functions in both native query and druidSql

### DIFF
--- a/rrollup
+++ b/rrollup
@@ -58,6 +58,7 @@ cat \
   build/expressions/greaterThanOrEqualExpression.js \
   build/expressions/inExpression.js \
   build/expressions/ipSearchExpression.js \
+  build/expressions/ipStringifyExpression.js \
   build/expressions/isExpression.js \
   build/expressions/joinExpression.js \
   build/expressions/lengthExpression.js \

--- a/rrollup
+++ b/rrollup
@@ -57,6 +57,7 @@ cat \
   build/expressions/greaterThanExpression.js \
   build/expressions/greaterThanOrEqualExpression.js \
   build/expressions/inExpression.js \
+  build/expressions/ipSearchExpression.js \
   build/expressions/isExpression.js \
   build/expressions/joinExpression.js \
   build/expressions/lengthExpression.js \

--- a/rrollup
+++ b/rrollup
@@ -57,6 +57,7 @@ cat \
   build/expressions/greaterThanExpression.js \
   build/expressions/greaterThanOrEqualExpression.js \
   build/expressions/inExpression.js \
+  build/expressions/ipMatchExpression.js \
   build/expressions/ipSearchExpression.js \
   build/expressions/ipStringifyExpression.js \
   build/expressions/isExpression.js \

--- a/src/dialect/baseDialect.ts
+++ b/src/dialect/baseDialect.ts
@@ -224,4 +224,8 @@ export abstract class SQLDialect {
   public lookupExpression(_base: string, _lookup: string): string {
     throw new Error('can not express a lookup as a function');
   }
+
+  public ipSearchExpression(_colName: string, _searchString: string): string {
+    throw new Error('must implement');
+  }
 }

--- a/src/dialect/baseDialect.ts
+++ b/src/dialect/baseDialect.ts
@@ -225,6 +225,10 @@ export abstract class SQLDialect {
     throw new Error('can not express a lookup as a function');
   }
 
+  public ipMatchExpression(_colName: string, _searchString: string): string {
+    throw new Error('must implement');
+  }
+
   public ipSearchExpression(_colName: string, _searchString: string): string {
     throw new Error('must implement');
   }

--- a/src/dialect/baseDialect.ts
+++ b/src/dialect/baseDialect.ts
@@ -225,7 +225,11 @@ export abstract class SQLDialect {
     throw new Error('can not express a lookup as a function');
   }
 
-  public ipMatchExpression(_colName: string, _searchString: string): string {
+  public ipMatchExpression(
+    _colName: string,
+    _searchString: string,
+    _ipSearchType?: string,
+  ): string {
     throw new Error('must implement');
   }
 

--- a/src/dialect/baseDialect.ts
+++ b/src/dialect/baseDialect.ts
@@ -229,7 +229,11 @@ export abstract class SQLDialect {
     throw new Error('must implement');
   }
 
-  public ipSearchExpression(_colName: string, _searchString: string): string {
+  public ipSearchExpression(
+    _colName: string,
+    _searchString: string,
+    _ipSearchType?: string,
+  ): string {
     throw new Error('must implement');
   }
 

--- a/src/dialect/baseDialect.ts
+++ b/src/dialect/baseDialect.ts
@@ -228,4 +228,8 @@ export abstract class SQLDialect {
   public ipSearchExpression(_colName: string, _searchString: string): string {
     throw new Error('must implement');
   }
+
+  public ipStringifyExpression(_operand: string): string {
+    throw new Error('must implement');
+  }
 }

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -252,8 +252,10 @@ export class DruidDialect extends SQLDialect {
     return `LOOKUP(${base}, ${this.escapeLiteral(lookup)})`;
   }
 
-  public ipMatchExpression(columnName: string, searchString: string): string {
-    return `IP_MATCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
+  public ipMatchExpression(columnName: string, searchString: string, ipSearchType: string): string {
+    return ipSearchType === 'ipPrefix'
+      ? `IP_MATCH(${this.escapeLiteral(searchString)}, ${this.ipPrefixParse(columnName)})`
+      : `IP_MATCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
   }
 
   public ipSearchExpression(

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -118,6 +118,10 @@ export class DruidDialect extends SQLDialect {
     return `IP_PARSE${value}`;
   }
 
+  public ipPrefixParse(value: string): string {
+    return `IP_PREFIX_PARSE${value}`;
+  }
+
   public concatExpression(a: string, b: string): string {
     return `(${a}||${b})`;
   }
@@ -252,8 +256,14 @@ export class DruidDialect extends SQLDialect {
     return `IP_MATCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
   }
 
-  public ipSearchExpression(columnName: string, searchString: string): string {
-    return `IP_SEARCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
+  public ipSearchExpression(
+    columnName: string,
+    searchString: string,
+    ipSearchType: string,
+  ): string {
+    return ipSearchType === 'ipPrefix'
+      ? `IP_SEARCH(${this.escapeLiteral(searchString)}, ${this.ipPrefixParse(columnName)})`
+      : `IP_SEARCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
   }
 
   public ipStringifyExpression(operand: string): string {

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -114,6 +114,10 @@ export class DruidDialect extends SQLDialect {
     return `ARRAY[${arr.join(',')}]`;
   }
 
+  public ipParse(value: string): string {
+    return `IP_PARSE${value}`;
+  }
+
   public concatExpression(a: string, b: string): string {
     return `(${a}||${b})`;
   }
@@ -242,5 +246,9 @@ export class DruidDialect extends SQLDialect {
 
   public lookupExpression(base: string, lookup: string): string {
     return `LOOKUP(${base}, ${this.escapeLiteral(lookup)})`;
+  }
+
+  public ipSearchExpression(columnName: string, searchString: string): string {
+    return `IP_SEARCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
   }
 }

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -248,6 +248,10 @@ export class DruidDialect extends SQLDialect {
     return `LOOKUP(${base}, ${this.escapeLiteral(lookup)})`;
   }
 
+  public ipMatchExpression(columnName: string, searchString: string): string {
+    return `IP_MATCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
+  }
+
   public ipSearchExpression(columnName: string, searchString: string): string {
     return `IP_SEARCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
   }

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -251,4 +251,8 @@ export class DruidDialect extends SQLDialect {
   public ipSearchExpression(columnName: string, searchString: string): string {
     return `IP_SEARCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
   }
+
+  public ipStringifyExpression(operand: string): string {
+    return `IP_STRINGIFY(${operand})`;
+  }
 }

--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -115,11 +115,11 @@ export class DruidDialect extends SQLDialect {
   }
 
   public ipParse(value: string): string {
-    return `IP_PARSE${value}`;
+    return `IP_PARSE(${value})`;
   }
 
   public ipPrefixParse(value: string): string {
-    return `IP_PREFIX_PARSE${value}`;
+    return `IP_PREFIX_PARSE(${value})`;
   }
 
   public concatExpression(a: string, b: string): string {

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -1300,8 +1300,12 @@ export abstract class Expression implements Instance<ExpressionValue, Expression
     return this._mkChain<OrExpression>(OrExpression, exs);
   }
 
-  public ipMatch(searchString: string) {
-    return new IpMatchExpression({ operand: this, ipSearchString: searchString });
+  public ipMatch(searchString: string, ipSearchType: string) {
+    return new IpMatchExpression({
+      operand: this,
+      ipSearchString: searchString,
+      ipSearchType: ipSearchType,
+    });
   }
 
   public ipSearch(searchString: string, ipSearchType: string) {

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -71,6 +71,7 @@ import { GreaterThanOrEqualExpression } from './greaterThanOrEqualExpression';
 import { IndexOfExpression } from './indexOfExpression';
 import { InExpression } from './inExpression';
 import { IpSearchExpression } from './ipSearchExpression';
+import { IpStringifyExpression } from './ipStringifyExpression';
 import { IsExpression } from './isExpression';
 import { JoinExpression } from './joinExpression';
 import { LengthExpression } from './lengthExpression';
@@ -1298,6 +1299,10 @@ export abstract class Expression implements Instance<ExpressionValue, Expression
 
   public ipSearch(searchString: string) {
     return new IpSearchExpression({ operand: this, ipSearchString: searchString });
+  }
+
+  public ipStringify() {
+    return new IpStringifyExpression({ operand: this });
   }
 
   // String manipulation

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -70,6 +70,7 @@ import { GreaterThanExpression } from './greaterThanExpression';
 import { GreaterThanOrEqualExpression } from './greaterThanOrEqualExpression';
 import { IndexOfExpression } from './indexOfExpression';
 import { InExpression } from './inExpression';
+import { IpMatchExpression } from './ipMatchExpression';
 import { IpSearchExpression } from './ipSearchExpression';
 import { IpStringifyExpression } from './ipStringifyExpression';
 import { IsExpression } from './isExpression';
@@ -1295,6 +1296,10 @@ export abstract class Expression implements Instance<ExpressionValue, Expression
 
   public or(...exs: any[]) {
     return this._mkChain<OrExpression>(OrExpression, exs);
+  }
+
+  public ipMatch(searchString: string) {
+    return new IpMatchExpression({ operand: this, ipSearchString: searchString });
   }
 
   public ipSearch(searchString: string) {

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -70,6 +70,7 @@ import { GreaterThanExpression } from './greaterThanExpression';
 import { GreaterThanOrEqualExpression } from './greaterThanOrEqualExpression';
 import { IndexOfExpression } from './indexOfExpression';
 import { InExpression } from './inExpression';
+import { IpSearchExpression } from './ipSearchExpression';
 import { IsExpression } from './isExpression';
 import { JoinExpression } from './joinExpression';
 import { LengthExpression } from './lengthExpression';
@@ -245,6 +246,7 @@ export interface ExpressionValue {
   tuning?: string;
   sql?: string;
   mvArray?: string[];
+  ipSearchString?: string;
 }
 
 export interface ExpressionJS {
@@ -282,6 +284,7 @@ export interface ExpressionJS {
   tuning?: string;
   sql?: string;
   mvArray?: string[];
+  ipSearchString?: string;
 }
 
 export interface ExtractAndRest {
@@ -1291,6 +1294,10 @@ export abstract class Expression implements Instance<ExpressionValue, Expression
 
   public or(...exs: any[]) {
     return this._mkChain<OrExpression>(OrExpression, exs);
+  }
+
+  public ipSearch(searchString: string) {
+    return new IpSearchExpression({ operand: this, ipSearchString: searchString });
   }
 
   // String manipulation

--- a/src/expressions/baseExpression.ts
+++ b/src/expressions/baseExpression.ts
@@ -249,6 +249,7 @@ export interface ExpressionValue {
   sql?: string;
   mvArray?: string[];
   ipSearchString?: string;
+  ipSearchType?: string;
 }
 
 export interface ExpressionJS {
@@ -287,6 +288,7 @@ export interface ExpressionJS {
   sql?: string;
   mvArray?: string[];
   ipSearchString?: string;
+  ipSearchType?: string;
 }
 
 export interface ExtractAndRest {
@@ -1302,8 +1304,12 @@ export abstract class Expression implements Instance<ExpressionValue, Expression
     return new IpMatchExpression({ operand: this, ipSearchString: searchString });
   }
 
-  public ipSearch(searchString: string) {
-    return new IpSearchExpression({ operand: this, ipSearchString: searchString });
+  public ipSearch(searchString: string, ipSearchType: string) {
+    return new IpSearchExpression({
+      operand: this,
+      ipSearchString: searchString,
+      ipSearchType: ipSearchType,
+    });
   }
 
   public ipStringify() {

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -39,6 +39,7 @@ export * from './greaterThanOrEqualExpression';
 export * from './indexOfExpression';
 export * from './inExpression';
 export * from './ipSearchExpression';
+export * from './ipStringifyExpression';
 export * from './isExpression';
 export * from './joinExpression';
 export * from './lengthExpression';

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -38,6 +38,7 @@ export * from './greaterThanExpression';
 export * from './greaterThanOrEqualExpression';
 export * from './indexOfExpression';
 export * from './inExpression';
+export * from './ipSearchExpression';
 export * from './isExpression';
 export * from './joinExpression';
 export * from './lengthExpression';

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -38,6 +38,7 @@ export * from './greaterThanExpression';
 export * from './greaterThanOrEqualExpression';
 export * from './indexOfExpression';
 export * from './inExpression';
+export * from './ipMatchExpression';
 export * from './ipSearchExpression';
 export * from './ipStringifyExpression';
 export * from './isExpression';

--- a/src/expressions/ipMatchExpression.ts
+++ b/src/expressions/ipMatchExpression.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2020 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SQLDialect } from '../dialect';
+
+import { ChainableExpression, Expression, ExpressionJS, ExpressionValue } from './baseExpression';
+
+export class IpMatchExpression extends ChainableExpression {
+  static op = 'ipMatch';
+  static fromJS(parameters: ExpressionJS): IpMatchExpression {
+    const value = ChainableExpression.jsToValue(parameters);
+    value.ipSearchString = parameters.ipSearchString;
+    return new IpMatchExpression(value);
+  }
+
+  constructor(parameters: ExpressionValue) {
+    super(parameters, dummyObject);
+    this._ensureOp('ipMatch');
+    this._checkOperandTypes('STRING');
+    this.ipSearchString = parameters.ipSearchString;
+    this.type = 'BOOLEAN';
+  }
+
+  public ipSearchString: string;
+
+  public valueOf(): ExpressionValue {
+    const value = super.valueOf();
+    value.ipSearchString = this.ipSearchString;
+    return value;
+  }
+
+  public equals(other: IpMatchExpression | undefined): boolean {
+    return super.equals(other) && this.ipSearchString === other.ipSearchString;
+  }
+
+  public toJS(): ExpressionJS {
+    const js = super.toJS();
+    js.ipSearchString = this.ipSearchString;
+    return js;
+  }
+
+  protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {
+    return dialect.ipMatchExpression(operandSQL, this.ipSearchString);
+  }
+}
+
+Expression.register(IpMatchExpression);

--- a/src/expressions/ipMatchExpression.ts
+++ b/src/expressions/ipMatchExpression.ts
@@ -23,6 +23,7 @@ export class IpMatchExpression extends ChainableExpression {
   static fromJS(parameters: ExpressionJS): IpMatchExpression {
     const value = ChainableExpression.jsToValue(parameters);
     value.ipSearchString = parameters.ipSearchString;
+    value.ipSearchType = parameters.ipSearchType;
     return new IpMatchExpression(value);
   }
 
@@ -31,29 +32,37 @@ export class IpMatchExpression extends ChainableExpression {
     this._ensureOp('ipMatch');
     this._checkOperandTypes('STRING');
     this.ipSearchString = parameters.ipSearchString;
+    this.ipSearchType = parameters.ipSearchType;
     this.type = 'BOOLEAN';
   }
 
   public ipSearchString: string;
+  public ipSearchType = 'ip';
 
   public valueOf(): ExpressionValue {
     const value = super.valueOf();
     value.ipSearchString = this.ipSearchString;
+    value.ipSearchType = this.ipSearchType;
     return value;
   }
 
   public equals(other: IpMatchExpression | undefined): boolean {
-    return super.equals(other) && this.ipSearchString === other.ipSearchString;
+    return (
+      super.equals(other) &&
+      this.ipSearchString === other.ipSearchString &&
+      this.ipSearchType === other.ipSearchType
+    );
   }
 
   public toJS(): ExpressionJS {
     const js = super.toJS();
     js.ipSearchString = this.ipSearchString;
+    js.ipSearchType = this.ipSearchType;
     return js;
   }
 
   protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {
-    return dialect.ipMatchExpression(operandSQL, this.ipSearchString);
+    return dialect.ipMatchExpression(operandSQL, this.ipSearchString, this.ipSearchType);
   }
 }
 

--- a/src/expressions/ipSearchExpression.ts
+++ b/src/expressions/ipSearchExpression.ts
@@ -23,6 +23,7 @@ export class IpSearchExpression extends ChainableExpression {
   static fromJS(parameters: ExpressionJS): IpSearchExpression {
     const value = ChainableExpression.jsToValue(parameters);
     value.ipSearchString = parameters.ipSearchString;
+    value.ipSearchType = parameters.ipSearchType;
     return new IpSearchExpression(value);
   }
 
@@ -31,29 +32,37 @@ export class IpSearchExpression extends ChainableExpression {
     this._ensureOp('ipSearch');
     this._checkOperandTypes('STRING');
     this.ipSearchString = parameters.ipSearchString;
+    this.ipSearchType = parameters.ipSearchType;
     this.type = 'BOOLEAN';
   }
 
   public ipSearchString: string;
+  public ipSearchType = 'ip';
 
   public valueOf(): ExpressionValue {
     const value = super.valueOf();
     value.ipSearchString = this.ipSearchString;
+    value.ipSearchType = this.ipSearchType;
     return value;
   }
 
   public equals(other: IpSearchExpression | undefined): boolean {
-    return super.equals(other) && this.ipSearchString === other.ipSearchString;
+    return (
+      super.equals(other) &&
+      this.ipSearchString === other.ipSearchString &&
+      this.ipSearchType === other.ipSearchType
+    );
   }
 
   public toJS(): ExpressionJS {
     const js = super.toJS();
     js.ipSearchString = this.ipSearchString;
+    js.ipSearchType = this.ipSearchType;
     return js;
   }
 
   protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {
-    return dialect.ipSearchExpression(operandSQL, this.ipSearchString);
+    return dialect.ipSearchExpression(operandSQL, this.ipSearchString, this.ipSearchType);
   }
 }
 

--- a/src/expressions/ipSearchExpression.ts
+++ b/src/expressions/ipSearchExpression.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2020 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SQLDialect } from '../dialect';
+
+import { ChainableExpression, Expression, ExpressionJS, ExpressionValue } from './baseExpression';
+
+export class IpSearchExpression extends ChainableExpression {
+  static op = 'IpSearch';
+  static fromJS(parameters: ExpressionJS): IpSearchExpression {
+    const value = ChainableExpression.jsToValue(parameters);
+    value.ipSearchString = parameters.ipSearchString;
+    return new IpSearchExpression(value);
+  }
+
+  constructor(parameters: ExpressionValue) {
+    super(parameters, dummyObject);
+    this._ensureOp('ipSearch');
+    this._checkOperandTypes('STRING');
+    this.ipSearchString = parameters.ipSearchString;
+    this.type = 'BOOLEAN';
+  }
+
+  public ipSearchString: string;
+
+  public valueOf(): ExpressionValue {
+    const value = super.valueOf();
+    value.ipSearchString = this.ipSearchString;
+    return value;
+  }
+
+  public toJS(): ExpressionJS {
+    const js = super.toJS();
+    js.ipSearchString = this.ipSearchString;
+    return js;
+  }
+
+  protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {
+    return dialect.ipSearchExpression(operandSQL, this.ipSearchString);
+  }
+}
+
+Expression.register(IpSearchExpression);

--- a/src/expressions/ipStringifyExpression.ts
+++ b/src/expressions/ipStringifyExpression.ts
@@ -18,43 +18,33 @@ import { SQLDialect } from '../dialect';
 
 import { ChainableExpression, Expression, ExpressionJS, ExpressionValue } from './baseExpression';
 
-export class IpSearchExpression extends ChainableExpression {
-  static op = 'IpSearch';
-  static fromJS(parameters: ExpressionJS): IpSearchExpression {
+export class IpStringifyExpression extends ChainableExpression {
+  static op = 'IpStringify';
+  static fromJS(parameters: ExpressionJS): IpStringifyExpression {
     const value = ChainableExpression.jsToValue(parameters);
-    value.ipSearchString = parameters.ipSearchString;
-    return new IpSearchExpression(value);
+    return new IpStringifyExpression(value);
   }
 
   constructor(parameters: ExpressionValue) {
     super(parameters, dummyObject);
-    this._ensureOp('ipSearch');
+    this._ensureOp('ipStringify');
     this._checkOperandTypes('STRING');
-    this.ipSearchString = parameters.ipSearchString;
-    this.type = 'BOOLEAN';
+    this.type = 'STRING';
   }
-
-  public ipSearchString: string;
 
   public valueOf(): ExpressionValue {
     const value = super.valueOf();
-    value.ipSearchString = this.ipSearchString;
     return value;
-  }
-
-  public equals(other: IpSearchExpression | undefined): boolean {
-    return super.equals(other) && this.ipSearchString === other.ipSearchString;
   }
 
   public toJS(): ExpressionJS {
     const js = super.toJS();
-    js.ipSearchString = this.ipSearchString;
     return js;
   }
 
   protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {
-    return dialect.ipSearchExpression(operandSQL, this.ipSearchString);
+    return dialect.ipStringifyExpression(operandSQL);
   }
 }
 
-Expression.register(IpSearchExpression);
+Expression.register(IpStringifyExpression);

--- a/src/external/utils/druidExpressionBuilder.ts
+++ b/src/external/utils/druidExpressionBuilder.ts
@@ -33,6 +33,7 @@ import {
   FallbackExpression,
   IndexOfExpression,
   IpSearchExpression,
+  IpStringifyExpression,
   IsExpression,
   LengthExpression,
   LiteralExpression,
@@ -247,6 +248,8 @@ export class DruidExpressionBuilder {
         return `ip_search(IP_PARSE(${ex1}), ${DruidExpressionBuilder.escapeLiteral(
           expression.ipSearchString,
         )})`;
+      } else if (expression instanceof IpStringifyExpression) {
+        return `ip_stringify(${ex1})`;
       } else if (expression instanceof ChainableUnaryExpression) {
         const myExpression = expression.expression;
 

--- a/src/external/utils/druidExpressionBuilder.ts
+++ b/src/external/utils/druidExpressionBuilder.ts
@@ -32,6 +32,7 @@ import {
   ExtractExpression,
   FallbackExpression,
   IndexOfExpression,
+  IpMatchExpression,
   IpSearchExpression,
   IpStringifyExpression,
   IsExpression,
@@ -244,8 +245,12 @@ export class DruidExpressionBuilder {
         return `array_overlap(${ex1}, [${expression.mvArray
           .map(DruidExpressionBuilder.escapeLiteral)
           .join(',')}])`;
+      } else if (expression instanceof IpMatchExpression) {
+        return `ip_match(${ex1}, ${DruidExpressionBuilder.escapeLiteral(
+          expression.ipSearchString,
+        )})`;
       } else if (expression instanceof IpSearchExpression) {
-        return `ip_search(IP_PARSE(${ex1}), ${DruidExpressionBuilder.escapeLiteral(
+        return `ip_search(${ex1}, ${DruidExpressionBuilder.escapeLiteral(
           expression.ipSearchString,
         )})`;
       } else if (expression instanceof IpStringifyExpression) {

--- a/src/external/utils/druidExpressionBuilder.ts
+++ b/src/external/utils/druidExpressionBuilder.ts
@@ -250,9 +250,9 @@ export class DruidExpressionBuilder {
           expression.ipSearchString,
         )})`;
       } else if (expression instanceof IpSearchExpression) {
-        return `ip_search(${ex1}, ${DruidExpressionBuilder.escapeLiteral(
-          expression.ipSearchString,
-        )})`;
+        return expression.ipSearchType === 'ipPrefix'
+          ? `ip_search(${DruidExpressionBuilder.escapeLiteral(expression.ipSearchString)}, ${ex1})`
+          : `ip_search(${ex1}, ${DruidExpressionBuilder.escapeLiteral(expression.ipSearchString)})`;
       } else if (expression instanceof IpStringifyExpression) {
         return `ip_stringify(${ex1})`;
       } else if (expression instanceof ChainableUnaryExpression) {

--- a/src/external/utils/druidExpressionBuilder.ts
+++ b/src/external/utils/druidExpressionBuilder.ts
@@ -246,9 +246,9 @@ export class DruidExpressionBuilder {
           .map(DruidExpressionBuilder.escapeLiteral)
           .join(',')}])`;
       } else if (expression instanceof IpMatchExpression) {
-        return `ip_match(${ex1}, ${DruidExpressionBuilder.escapeLiteral(
-          expression.ipSearchString,
-        )})`;
+        return expression.ipSearchType === 'ipPrefix'
+          ? `ip_match(${DruidExpressionBuilder.escapeLiteral(expression.ipSearchString)}, ${ex1})`
+          : `ip_match(${ex1}, ${DruidExpressionBuilder.escapeLiteral(expression.ipSearchString)})`;
       } else if (expression instanceof IpSearchExpression) {
         return expression.ipSearchType === 'ipPrefix'
           ? `ip_search(${DruidExpressionBuilder.escapeLiteral(expression.ipSearchString)}, ${ex1})`

--- a/src/external/utils/druidExpressionBuilder.ts
+++ b/src/external/utils/druidExpressionBuilder.ts
@@ -32,6 +32,7 @@ import {
   ExtractExpression,
   FallbackExpression,
   IndexOfExpression,
+  IpSearchExpression,
   IsExpression,
   LengthExpression,
   LiteralExpression,
@@ -242,6 +243,10 @@ export class DruidExpressionBuilder {
         return `array_overlap(${ex1}, [${expression.mvArray
           .map(DruidExpressionBuilder.escapeLiteral)
           .join(',')}])`;
+      } else if (expression instanceof IpSearchExpression) {
+        return `ip_search(IP_PARSE(${ex1}), ${DruidExpressionBuilder.escapeLiteral(
+          expression.ipSearchString,
+        )})`;
       } else if (expression instanceof ChainableUnaryExpression) {
         const myExpression = expression.expression;
 

--- a/src/external/utils/druidFilterBuilder.ts
+++ b/src/external/utils/druidFilterBuilder.ts
@@ -29,6 +29,7 @@ import {
   AndExpression,
   ContainsExpression,
   Expression,
+  IpSearchExpression,
   IsExpression,
   LiteralExpression,
   MatchExpression,
@@ -203,6 +204,8 @@ export class DruidFilterBuilder {
       return this.makeExpressionFilter(filter.operand.mvContains(filter.mvArray));
     } else if (filter instanceof MvOverlapExpression) {
       return this.makeExpressionFilter(filter.operand.mvOverlap(filter.mvArray));
+    } else if (filter instanceof IpSearchExpression) {
+      return this.makeExpressionFilter(filter.operand.ipSearch(filter.ipSearchString));
     }
 
     throw new Error(`could not convert filter ${filter} to Druid filter`);

--- a/src/external/utils/druidFilterBuilder.ts
+++ b/src/external/utils/druidFilterBuilder.ts
@@ -30,6 +30,7 @@ import {
   ContainsExpression,
   Expression,
   IpSearchExpression,
+  IpStringifyExpression,
   IsExpression,
   LiteralExpression,
   MatchExpression,
@@ -206,6 +207,8 @@ export class DruidFilterBuilder {
       return this.makeExpressionFilter(filter.operand.mvOverlap(filter.mvArray));
     } else if (filter instanceof IpSearchExpression) {
       return this.makeExpressionFilter(filter.operand.ipSearch(filter.ipSearchString));
+    } else if (filter instanceof IpStringifyExpression) {
+      return this.makeExpressionFilter(filter.operand.ipStringify());
     }
 
     throw new Error(`could not convert filter ${filter} to Druid filter`);

--- a/src/external/utils/druidFilterBuilder.ts
+++ b/src/external/utils/druidFilterBuilder.ts
@@ -207,7 +207,9 @@ export class DruidFilterBuilder {
     } else if (filter instanceof MvOverlapExpression) {
       return this.makeExpressionFilter(filter.operand.mvOverlap(filter.mvArray));
     } else if (filter instanceof IpMatchExpression) {
-      return this.makeExpressionFilter(filter.operand.ipMatch(filter.ipSearchString));
+      return this.makeExpressionFilter(
+        filter.operand.ipMatch(filter.ipSearchString, filter.ipSearchType),
+      );
     } else if (filter instanceof IpSearchExpression) {
       return this.makeExpressionFilter(
         filter.operand.ipSearch(filter.ipSearchString, filter.ipSearchType),

--- a/src/external/utils/druidFilterBuilder.ts
+++ b/src/external/utils/druidFilterBuilder.ts
@@ -29,6 +29,7 @@ import {
   AndExpression,
   ContainsExpression,
   Expression,
+  IpMatchExpression,
   IpSearchExpression,
   IpStringifyExpression,
   IsExpression,
@@ -205,6 +206,8 @@ export class DruidFilterBuilder {
       return this.makeExpressionFilter(filter.operand.mvContains(filter.mvArray));
     } else if (filter instanceof MvOverlapExpression) {
       return this.makeExpressionFilter(filter.operand.mvOverlap(filter.mvArray));
+    } else if (filter instanceof IpMatchExpression) {
+      return this.makeExpressionFilter(filter.operand.ipMatch(filter.ipSearchString));
     } else if (filter instanceof IpSearchExpression) {
       return this.makeExpressionFilter(filter.operand.ipSearch(filter.ipSearchString));
     } else if (filter instanceof IpStringifyExpression) {

--- a/src/external/utils/druidFilterBuilder.ts
+++ b/src/external/utils/druidFilterBuilder.ts
@@ -209,7 +209,9 @@ export class DruidFilterBuilder {
     } else if (filter instanceof IpMatchExpression) {
       return this.makeExpressionFilter(filter.operand.ipMatch(filter.ipSearchString));
     } else if (filter instanceof IpSearchExpression) {
-      return this.makeExpressionFilter(filter.operand.ipSearch(filter.ipSearchString));
+      return this.makeExpressionFilter(
+        filter.operand.ipSearch(filter.ipSearchString, filter.ipSearchType),
+      );
     } else if (filter instanceof IpStringifyExpression) {
       return this.makeExpressionFilter(filter.operand.ipStringify());
     }

--- a/test/expression/expression.mocha.js
+++ b/test/expression/expression.mocha.js
@@ -265,6 +265,10 @@ describe('Expression', () => {
           op: 'mvOverlap',
           mvArray: ['BMW', 'Honda', 'Suzuki'],
         },
+        {
+          op: 'ipSearch',
+          value: '192.0.0.0',
+        },
       ],
       {
         newThrows: true,

--- a/test/simulate/simulateDruid.mocha.js
+++ b/test/simulate/simulateDruid.mocha.js
@@ -36,6 +36,7 @@ const attributes = [
   { name: 'price', type: 'NUMBER', unsplitable: true },
   { name: 'tax', type: 'NUMBER', unsplitable: true },
   { name: 'vendor_id', type: 'NULL', nativeType: 'hyperUnique', unsplitable: true },
+  { name: 'ip_address', type: 'STRING' },
 
   { name: 'try', type: 'NUMBER', nativeType: 'STRING' }, // Added here because 'try' is a JS keyword
   { name: 'a+b', type: 'NUMBER', nativeType: 'STRING' }, // Added here because it is invalid JS without escaping
@@ -3461,6 +3462,7 @@ describe('simulate Druid', () => {
           'price',
           'tax',
           'vendor_id',
+          'ip_address',
           'try',
           'a+b',
         ],
@@ -3896,6 +3898,72 @@ describe('simulate Druid', () => {
       dimension: 'carat',
       lower: -10,
       type: 'bound',
+    });
+  });
+
+  it('works with ip address string dimension having ip_search filter expression', () => {
+    const ex = $('diamonds')
+      .filter($('ip_address').ipSearch('192.0.2.0'))
+      .split({ Ip_address: '$ip_address' })
+      .apply('Count', '$diamonds.count()');
+
+    const queryPlan = ex.simulateQueryPlan(context);
+    expect(queryPlan.length).to.equal(1);
+    expect(queryPlan[0][0]).to.deep.equal({
+      aggregations: [
+        {
+          name: 'Count',
+          type: 'count',
+        },
+      ],
+      dataSource: 'diamonds',
+      dimensions: [
+        {
+          dimension: 'ip_address',
+          outputName: 'Ip_address',
+          type: 'default',
+        },
+      ],
+      filter: {
+        type: 'expression',
+        expression: 'ip_search("ip_address", \'192.0.2.0\')',
+      },
+      granularity: 'all',
+      intervals: '2015-03-12T00Z/2015-03-19T00Z',
+      queryType: 'groupBy',
+    });
+  });
+
+  it('works with ip address string dimension having ip_match filter expression', () => {
+    const ex = $('diamonds')
+      .filter($('ip_address').ipMatch('192.0.2.0'))
+      .split({ Ip_address: '$ip_address' })
+      .apply('Count', '$diamonds.count()');
+
+    const queryPlan = ex.simulateQueryPlan(context);
+    expect(queryPlan.length).to.equal(1);
+    expect(queryPlan[0][0]).to.deep.equal({
+      aggregations: [
+        {
+          name: 'Count',
+          type: 'count',
+        },
+      ],
+      dataSource: 'diamonds',
+      dimensions: [
+        {
+          dimension: 'ip_address',
+          outputName: 'Ip_address',
+          type: 'default',
+        },
+      ],
+      filter: {
+        type: 'expression',
+        expression: 'ip_match("ip_address", \'192.0.2.0\')',
+      },
+      granularity: 'all',
+      intervals: '2015-03-12T00Z/2015-03-19T00Z',
+      queryType: 'groupBy',
     });
   });
 });

--- a/test/simulate/simulateDruid.mocha.js
+++ b/test/simulate/simulateDruid.mocha.js
@@ -3934,6 +3934,39 @@ describe('simulate Druid', () => {
     });
   });
 
+  it('works with ip prefix string dimension having ip_search filter expression', () => {
+    const ex = $('diamonds')
+      .filter($('ip_address').ipSearch('192.0.2.0', 'ipPrefix'))
+      .split({ Ip_address: '$ip_address' })
+      .apply('Count', '$diamonds.count()');
+
+    const queryPlan = ex.simulateQueryPlan(context);
+    expect(queryPlan.length).to.equal(1);
+    expect(queryPlan[0][0]).to.deep.equal({
+      aggregations: [
+        {
+          name: 'Count',
+          type: 'count',
+        },
+      ],
+      dataSource: 'diamonds',
+      dimensions: [
+        {
+          dimension: 'ip_address',
+          outputName: 'Ip_address',
+          type: 'default',
+        },
+      ],
+      filter: {
+        type: 'expression',
+        expression: 'ip_search(\'192.0.2.0\', "ip_address")',
+      },
+      granularity: 'all',
+      intervals: '2015-03-12T00Z/2015-03-19T00Z',
+      queryType: 'groupBy',
+    });
+  });
+
   it('works with ip address string dimension having ip_match filter expression', () => {
     const ex = $('diamonds')
       .filter($('ip_address').ipMatch('192.0.2.0'))

--- a/test/simulate/simulateDruid.mocha.js
+++ b/test/simulate/simulateDruid.mocha.js
@@ -37,6 +37,7 @@ const attributes = [
   { name: 'tax', type: 'NUMBER', unsplitable: true },
   { name: 'vendor_id', type: 'NULL', nativeType: 'hyperUnique', unsplitable: true },
   { name: 'ip_address', type: 'STRING' },
+  { name: 'ip_prefix', type: 'STRING' },
 
   { name: 'try', type: 'NUMBER', nativeType: 'STRING' }, // Added here because 'try' is a JS keyword
   { name: 'a+b', type: 'NUMBER', nativeType: 'STRING' }, // Added here because it is invalid JS without escaping
@@ -3463,6 +3464,7 @@ describe('simulate Druid', () => {
           'tax',
           'vendor_id',
           'ip_address',
+          'ip_prefix',
           'try',
           'a+b',
         ],
@@ -3936,8 +3938,8 @@ describe('simulate Druid', () => {
 
   it('works with ip prefix string dimension having ip_search filter expression', () => {
     const ex = $('diamonds')
-      .filter($('ip_address').ipSearch('192.0.2.0', 'ipPrefix'))
-      .split({ Ip_address: '$ip_address' })
+      .filter($('ip_prefix').ipSearch('192.0.2.0', 'ipPrefix'))
+      .split({ Ip_prefix: '$ip_prefix' })
       .apply('Count', '$diamonds.count()');
 
     const queryPlan = ex.simulateQueryPlan(context);
@@ -3952,14 +3954,14 @@ describe('simulate Druid', () => {
       dataSource: 'diamonds',
       dimensions: [
         {
-          dimension: 'ip_address',
-          outputName: 'Ip_address',
+          dimension: 'ip_prefix',
+          outputName: 'Ip_prefix',
           type: 'default',
         },
       ],
       filter: {
         type: 'expression',
-        expression: 'ip_search(\'192.0.2.0\', "ip_address")',
+        expression: 'ip_search(\'192.0.2.0\', "ip_prefix")',
       },
       granularity: 'all',
       intervals: '2015-03-12T00Z/2015-03-19T00Z',
@@ -3993,6 +3995,39 @@ describe('simulate Druid', () => {
       filter: {
         type: 'expression',
         expression: 'ip_match("ip_address", \'192.0.2.0\')',
+      },
+      granularity: 'all',
+      intervals: '2015-03-12T00Z/2015-03-19T00Z',
+      queryType: 'groupBy',
+    });
+  });
+
+  it('works with ip prefix string dimension having ip_match filter expression', () => {
+    const ex = $('diamonds')
+      .filter($('ip_prefix').ipMatch('192.0.2.0', 'ipPrefix'))
+      .split({ Ip_prefix: '$ip_prefix' })
+      .apply('Count', '$diamonds.count()');
+
+    const queryPlan = ex.simulateQueryPlan(context);
+    expect(queryPlan.length).to.equal(1);
+    expect(queryPlan[0][0]).to.deep.equal({
+      aggregations: [
+        {
+          name: 'Count',
+          type: 'count',
+        },
+      ],
+      dataSource: 'diamonds',
+      dimensions: [
+        {
+          dimension: 'ip_prefix',
+          outputName: 'Ip_prefix',
+          type: 'default',
+        },
+      ],
+      filter: {
+        type: 'expression',
+        expression: 'ip_match(\'192.0.2.0\', "ip_prefix")',
       },
       granularity: 'all',
       intervals: '2015-03-12T00Z/2015-03-19T00Z',

--- a/test/simulate/simulateDruidSql.mocha.js
+++ b/test/simulate/simulateDruidSql.mocha.js
@@ -361,7 +361,7 @@ describe('simulate DruidSql', () => {
       [
         {
           query:
-            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH(IP_PARSE"ip_address", \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH(IP_PARSE("ip_address"), \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);
@@ -398,7 +398,7 @@ describe('simulate DruidSql', () => {
       [
         {
           query:
-            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH(\'192.0\', IP_PREFIX_PARSE"ip_prefix")\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH(\'192.0\', IP_PREFIX_PARSE("ip_prefix"))\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);
@@ -435,7 +435,7 @@ describe('simulate DruidSql', () => {
       [
         {
           query:
-            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH(IP_PARSE"ip_address", \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH(IP_PARSE("ip_address"), \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);
@@ -472,7 +472,7 @@ describe('simulate DruidSql', () => {
       [
         {
           query:
-            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH(\'192.0.1.0/16\', IP_PREFIX_PARSE"ip_prefix")\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH(\'192.0.1.0/16\', IP_PREFIX_PARSE("ip_prefix"))\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);


### PR DESCRIPTION
- Added two new expressions, `ipSearchExpression` and `ipMatchExpression`, into plywood to support `ip_search` and `ip_match` functions on ip/ip prefix columns. 

- Need to support both native query and druidSQL.