### PR TITLE
IMPLY-28452 strip IP_STRINGIFY modifier in the column name for ip functions

### DIFF
--- a/src/dialect/druidDialect.ts
+++ b/src/dialect/druidDialect.ts
@@ -254,8 +254,8 @@ export class DruidDialect extends SQLDialect {
 
   public ipMatchExpression(columnName: string, searchString: string, ipSearchType: string): string {
     return ipSearchType === 'ipPrefix'
-      ? `IP_MATCH(${this.escapeLiteral(searchString)}, ${this.ipPrefixParse(columnName)})`
-      : `IP_MATCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
+      ? `IP_MATCH(${this.escapeLiteral(searchString)}, ${columnName.replace('IP_STRINGIFY', '')})`
+      : `IP_MATCH(${columnName.replace('IP_STRINGIFY', '')}, ${this.escapeLiteral(searchString)})`;
   }
 
   public ipSearchExpression(
@@ -264,8 +264,8 @@ export class DruidDialect extends SQLDialect {
     ipSearchType: string,
   ): string {
     return ipSearchType === 'ipPrefix'
-      ? `IP_SEARCH(${this.escapeLiteral(searchString)}, ${this.ipPrefixParse(columnName)})`
-      : `IP_SEARCH(${this.ipParse(columnName)}, ${this.escapeLiteral(searchString)})`;
+      ? `IP_SEARCH(${this.escapeLiteral(searchString)}, ${columnName.replace('IP_STRINGIFY', '')})`
+      : `IP_SEARCH(${columnName.replace('IP_STRINGIFY', '')}, ${this.escapeLiteral(searchString)})`;
   }
 
   public ipStringifyExpression(operand: string): string {

--- a/test/simulate/simulateDruidSql.mocha.js
+++ b/test/simulate/simulateDruidSql.mocha.js
@@ -391,7 +391,7 @@ describe('simulate DruidSql', () => {
             sqlTimeZone: 'Etc/UTC',
           },
           query:
-            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH(IP_PARSE("ip_address"), \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH("ip_address", \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);
@@ -431,7 +431,7 @@ describe('simulate DruidSql', () => {
             sqlTimeZone: 'Etc/UTC',
           },
           query:
-            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH(\'192.0\', IP_PREFIX_PARSE("ip_prefix"))\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_SEARCH(\'192.0\', "ip_prefix")\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);
@@ -472,7 +472,7 @@ describe('simulate DruidSql', () => {
           },
 
           query:
-            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH(IP_PARSE("ip_address"), \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_address) AS "Ip_address",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH("ip_address", \'192.0\')\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);
@@ -512,7 +512,7 @@ describe('simulate DruidSql', () => {
             sqlTimeZone: 'Etc/UTC',
           },
           query:
-            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH(\'192.0.1.0/16\', IP_PREFIX_PARSE("ip_prefix"))\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
+            'SELECT\n(t.ip_prefix) AS "Ip_prefix",\nCOUNT(*) AS "count"\nFROM "diamonds" AS t\nWHERE IP_MATCH(\'192.0.1.0/16\', "ip_prefix")\nGROUP BY 1\nORDER BY "count" DESC\nLIMIT 10',
         },
       ],
     ]);


### PR DESCRIPTION
In Pivot we added `IP_STRINGIFY` to column formula for ip related columns. Previously `IP_PARSE/ IP_PREFIX_PARSE` were added to those columns when generating ip function expressions, which leads to slow performance as identified in this [ticket](https://implydata.atlassian.net/browse/REQ-4120). 
This PR updates the IP expressions, on the assumption that IP related columns will be wrapped with `IP_STRINGIFY` function, instead of adding another parse function, we strip `IP_STRINGIFY` from the column formula. 

Query generated before:
<img width="1187" alt="Screenshot 2022-11-17 at 5 57 03 PM" src="https://user-images.githubusercontent.com/6841757/202599107-bdcc6b6f-ada3-4b20-b2c7-d7717bf4081a.png">

Query generated after:
<img width="1292" alt="Screenshot 2022-11-17 at 5 55 24 PM" src="https://user-images.githubusercontent.com/6841757/202599139-dd69d3c1-074f-412d-9800-018486f36fce.png">
