### PR TITLE
Added ability to convert inExpression to SQL

### DIFF
--- a/src/expressions/inExpression.ts
+++ b/src/expressions/inExpression.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { NumberRange, PlywoodValue, Range, Set, StringRange, TimeRange } from '../datatypes/index';
+import { PlywoodValue, Range, Set, StringRange } from '../datatypes/index';
 import { SQLDialect } from '../dialect/baseDialect';
 
 import {
@@ -91,19 +91,6 @@ export class InExpression extends ChainableUnaryExpression {
     const expression = this.expression;
     const expressionType = expression.type;
     switch (expressionType) {
-      case 'NUMBER_RANGE':
-      case 'TIME_RANGE':
-        if (expression instanceof LiteralExpression) {
-          const range: NumberRange | TimeRange = expression.value;
-          return dialect.inExpression(
-            operandSQL,
-            dialect.numberOrTimeToSQL(range.start),
-            dialect.numberOrTimeToSQL(range.end),
-            range.bounds,
-          );
-        }
-        throw new Error(`can not convert action to SQL ${this}`);
-
       case 'STRING_RANGE':
         if (expression instanceof LiteralExpression) {
           const stringRange: StringRange = expression.value;
@@ -116,26 +103,6 @@ export class InExpression extends ChainableUnaryExpression {
         }
         throw new Error(`can not convert action to SQL ${this}`);
 
-      case 'SET/NUMBER_RANGE':
-      case 'SET/TIME_RANGE':
-        if (expression instanceof LiteralExpression) {
-          const setOfRange: Set = expression.value;
-          return (
-            '(' +
-            setOfRange.elements
-              .map((range: NumberRange | TimeRange) => {
-                return dialect.inExpression(
-                  operandSQL,
-                  dialect.numberOrTimeToSQL(range.start),
-                  dialect.numberOrTimeToSQL(range.end),
-                  range.bounds,
-                );
-              })
-              .join(' OR ') +
-            ')'
-          );
-        }
-        throw new Error(`can not convert action to SQL ${this}`);
       case 'SET/STRING':
         if (expression instanceof LiteralExpression) {
           const setOfRange: Set = expression.value;

--- a/test/expression/inExpression.mocha.js
+++ b/test/expression/inExpression.mocha.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2020 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { expect } = require('chai');
+
+const plywood = require('../plywood');
+const { SQLDialect } = require("../plywood");
+
+const { $, ply, r, Expression } = plywood;
+
+class TestingDialect extends SQLDialect {
+  constructor() {
+    super();
+  }
+}
+
+describe('InExpression', () => {
+    it('_getSQLChainableUnaryHelper', () => {
+      const inExpression = Expression._.in(['thing', 'otherThing']);
+      const dialect = new TestingDialect()
+
+      expect(inExpression._getSQLChainableUnaryHelper(dialect, 'column')).to.equal("(column='thing' OR column='otherThing')");
+    });
+});

--- a/test/expression/inExpression.mocha.js
+++ b/test/expression/inExpression.mocha.js
@@ -28,10 +28,19 @@ class TestingDialect extends SQLDialect {
 }
 
 describe('InExpression', () => {
-    it('_getSQLChainableUnaryHelper', () => {
-      const inExpression = Expression._.in(['thing', 'otherThing']);
+  describe('_getSQLChainableUnaryHelper', () => {
+    it('works with more than one column', () => {
+      const inExpression = Expression._.in(['thing', 'otherThing', 'otherOtherThing']);
       const dialect = new TestingDialect()
 
-      expect(inExpression._getSQLChainableUnaryHelper(dialect, 'column')).to.equal("(column='thing' OR column='otherThing')");
+      expect(inExpression._getSQLChainableUnaryHelper(dialect, 't."column"')).to.equal(`(t."column"='thing' OR t."column"='otherThing' OR t."column"='otherOtherThing')`);
     });
+
+    it('works with single column', () => {
+      const inExpression = Expression._.in(['thing']);
+      const dialect = new TestingDialect()
+
+      expect(inExpression._getSQLChainableUnaryHelper(dialect, 't."column"')).to.equal(`(t."column"='thing')`);
+    });
+  })
 });


### PR DESCRIPTION
This will allow conversion from a plywood inExpression (`$columnName.in(valuesArray)`) to SQL. 

Examples:
- `$first_name.in(['Onfroi'])` -> `(t."first_name"='Onfroi')`
- `$first_name.in(['Onfroi', 'Derby'])` -> `(t."first_name"='Onfroi' OR t."first_name"='Derby')`
- `$first_name.in(['Onfroi', 'Derby', 'Brier'])` -> `(t."first_name"='Onfroi' OR t."first_name"='Derby' OR t."first_name"='Brier')`

Note: The added tests are testing `simulateQueryPlan` which does not utilize `inExpression._getSQLChainableUnaryHelper` but I left them there because I wrote them and they seemed like useful tests.