### PR TITLE
Fix Plywood Set constructor function does not handle null/"null" and falsy values properly

### DIFF
--- a/src/datatypes/set.ts
+++ b/src/datatypes/set.ts
@@ -43,7 +43,7 @@ function dateString(date: Date): string {
 }
 
 function stringKeyFn(value: any): string {
-  if (value == null) {
+  if (value === null) {
     return '__NULL_KEY_HASH_INTERNAL_USE_ONLY__';
   }
   return String(value);

--- a/src/datatypes/set.ts
+++ b/src/datatypes/set.ts
@@ -42,6 +42,13 @@ function dateString(date: Date): string {
   return date.toISOString();
 }
 
+function stringKeyFn(value: any): string {
+  if (value == null) {
+    return '__NULL_KEY_HASH_INTERNAL_USE_ONLY__';
+  }
+  return String(value);
+}
+
 function arrayFromJS(xs: Array<any>, setType: string): Array<any> {
   return xs.map(x => valueFromJS(x, setType));
 }
@@ -244,7 +251,7 @@ export class Set implements Instance<SetValue, SetJS> {
   constructor(parameters: SetValue) {
     const setType = parameters.setType;
     this.setType = setType;
-    const keyFn = setType === 'TIME' ? dateString : String;
+    const keyFn = setType === 'TIME' ? dateString : stringKeyFn;
     this.keyFn = keyFn;
 
     let elements = parameters.elements;

--- a/src/datatypes/set.ts
+++ b/src/datatypes/set.ts
@@ -260,7 +260,7 @@ export class Set implements Instance<SetValue, SetJS> {
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i];
       const key = keyFn(element);
-      if (hash[key]) {
+      if (hasOwnProp(hash, key)) {
         if (!newElements) newElements = elements.slice(0, i);
       } else {
         hash[key] = element;

--- a/test/datatypes/set.mocha.js
+++ b/test/datatypes/set.mocha.js
@@ -677,8 +677,17 @@ describe('Set', () => {
         setType: 'STRING',
         elements: [null, 'null', 'other'],
       });
+
       expect(set.has(null)).to.equal(true);
+      /*
+        If null is hashed correctly by the keyFn, then 'null' should be in the set too.
+        What we really test here is expecting generalEqual(hash[keyFn('null')], 'null') = true
+      **/
       expect(set.has('null')).to.equal(true);
+
+      // If null is hashed correcly by the keyFn, then only null should be removed.
+      expect(set.remove(null).size()).to.equal(set.size() - 1);
+      expect(set.has('null')).to.equal(true).to.equal(true);
     });
   });
 });

--- a/test/datatypes/set.mocha.js
+++ b/test/datatypes/set.mocha.js
@@ -672,7 +672,7 @@ describe('Set', () => {
   });
 
   describe('#constructor', () => {
-    it('initiates correctly when null and null string are both in elements', () => {
+    it('initializes correctly when null and null string are both in elements', () => {
       const set = Set.fromJS({
         setType: 'STRING',
         elements: [null, 'null', 'other'],
@@ -690,7 +690,7 @@ describe('Set', () => {
       expect(set.has('null')).to.equal(true).to.equal(true);
     });
 
-    it('initiates correctly when falsy and duplicate values are in elements', () => {
+    it('initializes correctly when falsy and duplicate values are in elements', () => {
       const set = Set.fromJS({
         setType: 'NUMBER',
         elements: [null, null, 0, 0],

--- a/test/datatypes/set.mocha.js
+++ b/test/datatypes/set.mocha.js
@@ -689,5 +689,18 @@ describe('Set', () => {
       expect(set.remove(null).size()).to.equal(set.size() - 1);
       expect(set.has('null')).to.equal(true).to.equal(true);
     });
+
+    it('initiates correctly when falsy and duplicate values are in elements', () => {
+      const set = Set.fromJS({
+        setType: 'NUMBER',
+        elements: [null, null, 0, 0],
+      });
+
+      expect(set.has(null)).to.equal(true);
+      expect(set.has(0)).to.equal(true);
+
+      // ensure it does not add falsy value twice
+      expect(set.size()).to.equal(2);
+    });
   });
 });

--- a/test/datatypes/set.mocha.js
+++ b/test/datatypes/set.mocha.js
@@ -670,4 +670,15 @@ describe('Set', () => {
       ).to.equal(true);
     });
   });
+
+  describe('#constructor', () => {
+    it('initiates correctly when null and null string are both in elements', () => {
+      const set = Set.fromJS({
+        setType: 'STRING',
+        elements: [null, 'null', 'other'],
+      });
+      expect(set.has(null)).to.equal(true);
+      expect(set.has('null')).to.equal(true);
+    });
+  });
 });

--- a/test/simulate/simulateDruidSql.mocha.js
+++ b/test/simulate/simulateDruidSql.mocha.js
@@ -231,7 +231,10 @@ describe('simulate DruidSql', () => {
 
   it('works with duplicate falsy values in a filter expression', () => {
     const ex = ply()
-      .apply('diamonds', $('diamonds').filter('$tags.overlap(["tagA", "tagB", null, "null"])'))
+      .apply(
+        'diamonds',
+        $('diamonds').filter('$tags.overlap(["tagA", "tagB", null, "null", "", ""])'),
+      )
       .apply('Tags', $('diamonds').split('$tags', 'Tag'));
 
     const queryPlan = ex.simulateQueryPlan({
@@ -253,7 +256,7 @@ describe('simulate DruidSql', () => {
             sqlTimeZone: 'Etc/UTC',
           },
           query:
-            'SELECT\n"tags" AS "Tag"\nFROM "dia.monds" AS t\nWHERE (NOT((("pugs" IS NULL) OR "pugs" IN (\'pugA\',\'pugB\',\'null\', \'\'))) AND (("tags" IS NULL) OR "tags" IN (\'tagA\',\'tagB\',\'null\')))\nGROUP BY 1',
+            'SELECT\n"tags" AS "Tag"\nFROM "dia.monds" AS t\nWHERE (NOT((("pugs" IS NULL) OR "pugs" IN (\'pugA\',\'pugB\',\'\'))) AND (("tags" IS NULL) OR "tags" IN (\'tagA\',\'tagB\',\'null\',\'\')))\nGROUP BY 1',
         },
       ],
     ]);

--- a/test/simulate/simulateDruidSql.mocha.js
+++ b/test/simulate/simulateDruidSql.mocha.js
@@ -199,6 +199,36 @@ describe('simulate DruidSql', () => {
     ]);
   });
 
+  it('works with null and null string are both included in a filter expression', () => {
+    const ex = ply()
+      .apply('diamonds', $('diamonds').filter('$tags.overlap(["tagA", "tagB", null, "null"])'))
+      .apply('Tags', $('diamonds').split('$tags', 'Tag'));
+
+    const queryPlan = ex.simulateQueryPlan({
+      diamonds: External.fromJS({
+        engine: 'druidsql',
+        version: '0.20.0',
+        source: 'dia.monds',
+        timeAttribute: 'time',
+        attributes,
+        allowSelectQueries: true,
+        filter: $('pugs').overlap(['pugA', 'pugB', null, 'null']).not(),
+      }),
+    });
+    expect(queryPlan.length).to.equal(1);
+    expect(queryPlan).to.deep.equal([
+      [
+        {
+          context: {
+            sqlTimeZone: 'Etc/UTC',
+          },
+          query:
+            'SELECT\n"tags" AS "Tag"\nFROM "dia.monds" AS t\nWHERE (NOT((("pugs" IS NULL) OR "pugs" IN (\'pugA\',\'pugB\',\'null\'))) AND (("tags" IS NULL) OR "tags" IN (\'tagA\',\'tagB\',\'null\')))\nGROUP BY 1',
+        },
+      ],
+    ]);
+  });
+
   it('works with sqlRefExpression', () => {
     const ex = ply().apply(
       'Tags',


### PR DESCRIPTION
This PR fixes the Plywood Set constructor function so that:

1. Plywoods generates the correct SQL query when both null and "null" are in a set. 
_Before_
`$('tags').overlap(['A', 'B', null, 'null'])` translates to `'tags' IN ['A', 'B', NULL, 'null']`,
_After_
`$('tags').overlap(['A', 'B', null, 'null'])` translates to `'tags' IS NULL OR 'tags' IN ['A', 'B', 'null']`,

2. Set can dedupe duplicate falsy values.