### PR TITLE
Fix sql ref expression to string function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plywood",
-  "version": "0.29.3",
+  "version": "0.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plywood",
-  "version": "0.29.3",
+  "version": "0.30.0",
   "description": "A query planner and executor",
   "keywords": [
     "split",

--- a/src/expressions/sqlRefExpression.ts
+++ b/src/expressions/sqlRefExpression.ts
@@ -61,7 +61,7 @@ export class SqlRefExpression extends Expression {
   }
 
   public toString(): string {
-    return `s$\{${this.sql}, ${this.type}`;
+    return `s$\{${this.sql}, ${this.type}\}`;
   }
 
   public changeSql(sql: string): SqlRefExpression {

--- a/test/expression/sqlRefExpression.mocha.js
+++ b/test/expression/sqlRefExpression.mocha.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2015 Metamarkets Group Inc.
+ * Copyright 2015-2020 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { expect } = require('chai');
+
+const plywood = require('../plywood');
+
+const { SqlRefExpression } = plywood;
+
+describe('SqlRefExpression', () => {
+  it('.toString should work with type', () => {
+    const sqlRefExpression = SqlRefExpression.fromJS({
+      op: 'sqlRef',
+      sql: `t.\"ip\"`,
+      type: 'IP',
+    });
+
+    expect(sqlRefExpression.toString()).to.equal('s${t."ip", IP}');
+  });
+
+  it('.toString should work without type', () => {
+    const sqlRefExpression = SqlRefExpression.fromJS({
+      op: 'sqlRef',
+      sql: `t.\"ip\"`,
+    });
+
+    expect(sqlRefExpression.toString()).to.equal('s${t."ip", undefined}');
+  });
+});


### PR DESCRIPTION
Added `}` to the end of SqlRefExpression.toString