### PR TITLE
Added ability to express type for SqlRefExpression in plywood's expression language

### DIFF
--- a/src/expressions/expression.pegjs
+++ b/src/expressions/expression.pegjs
@@ -188,11 +188,17 @@ RefExpression
     { return RefExpression.parse(name); }
 
 SqlRefExpression
-  = "s$" sql:SqlBody
-    { return new SqlRefExpression({ sql: sql }); }
+  = "s$" sqlRef:SqlRefObject
+    { return new SqlRefExpression(sqlRef); }
 
-SqlBody
-  = "{" sql:$([^}]+) "}" { return sql; }
+SqlRefObject
+  = "{" sql:$([^}]+) "}" type:(":" TypeName)? {
+    if (type) {
+      return { sql: sql, type: type[1] }
+    }
+
+    return { sql: sql }
+  }
 
 LiteralExpression
   = value:(NullToken / FalseToken / TrueToken) { return r(value); }

--- a/src/expressions/sqlRefExpression.ts
+++ b/src/expressions/sqlRefExpression.ts
@@ -61,7 +61,9 @@ export class SqlRefExpression extends Expression {
   }
 
   public toString(): string {
-    return `s$\{${this.sql}, ${this.type}\}`;
+    const { sql, type } = this;
+
+    return type ? `s$\{${sql}\}:${type}` : `s$\{${sql}\}`;
   }
 
   public changeSql(sql: string): SqlRefExpression {

--- a/test/expression/sqlRefExpression.mocha.js
+++ b/test/expression/sqlRefExpression.mocha.js
@@ -29,7 +29,7 @@ describe('SqlRefExpression', () => {
       type: 'IP',
     });
 
-    expect(sqlRefExpression.toString()).to.equal('s${t."ip", IP}');
+    expect(sqlRefExpression.toString()).to.equal('s${t."ip"}:IP');
   });
 
   it('.toString should work without type', () => {
@@ -38,6 +38,6 @@ describe('SqlRefExpression', () => {
       sql: `t.\"ip\"`,
     });
 
-    expect(sqlRefExpression.toString()).to.equal('s${t."ip", undefined}');
+    expect(sqlRefExpression.toString()).to.equal('s${t."ip"}');
   });
 });

--- a/test/parser/expressionParser.mocha.js
+++ b/test/parser/expressionParser.mocha.js
@@ -237,6 +237,13 @@ describe('expression parser', () => {
       expect(ex1.toJS()).to.deep.equal(ex2.toJS());
     });
 
+    it('should work with SQL with type', () => {
+      const ex1 = Expression.parse('s${SUBSTR(A, 1, 2)}:IP');
+      const ex2 = s$(`SUBSTR(A, 1, 2)`, 'IP');
+
+      expect(ex1.toJS()).to.deep.equal(ex2.toJS());
+    });
+
     it('should handle --', () => {
       const ex1 = Expression.parse('$x--3');
       const ex2 = $('x').subtract(-3);
@@ -254,6 +261,13 @@ describe('expression parser', () => {
     it('should work with lots of keywords 2', () => {
       const ex1 = Expression.parse('true and $y and true and $z');
       const ex2 = r(true).and($('y'), r(true), $('z'));
+
+      expect(ex1.toJS()).to.deep.equal(ex2.toJS());
+    });
+
+    it('should work with type', () => {
+      const ex1 = Expression.parse('${ipThing}:IP');
+      const ex2 = $(`ipThing`, 'IP');
 
       expect(ex1.toJS()).to.deep.equal(ex2.toJS());
     });


### PR DESCRIPTION
This is a follow-up PR for #271 to make sure `Expression.parse` can parse string defined SqlRefExpressions (ex. `s${t.column}:IP`)