### PR TITLE
Fix bug when generating select sql when IP_MATCH or IP_SEARCH is included

### DIFF
--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myRunOnSave" value="true" />
+    <option name="myRunOnReformat" value="true" />
+  </component>
+</project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plywood",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plywood",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "A query planner and executor",
   "keywords": [
     "split",

--- a/rrollup
+++ b/rrollup
@@ -11,6 +11,7 @@ cat \
   build/helper/verboseRequester.js \
   build/helper/retryRequester.js \
   build/helper/concurrentLimitRequester.js \
+  build/helper/containsSqlFunction.js \
   build/helper/promiseWhile.js \
   build/helper/streamBasics.js \
   build/helper/streamConcat.js \

--- a/src/expressions/splitExpression.ts
+++ b/src/expressions/splitExpression.ts
@@ -34,6 +34,7 @@ import {
   SubstitutionFn,
 } from './baseExpression';
 import { Aggregate } from './mixins/aggregate';
+import { SqlRefExpression } from './sqlRefExpression';
 
 export class SplitExpression extends ChainableExpression implements Aggregate {
   static op = 'Split';
@@ -200,7 +201,11 @@ export class SplitExpression extends ChainableExpression implements Aggregate {
 
   public getSelectSQL(dialect: SQLDialect): string[] {
     return this.mapSplits((name, expression) => {
-      if (['IP', 'SET/IP'].includes(expression.type)) {
+      if (
+        expression instanceof SqlRefExpression &&
+        ['IP', 'SET/IP'].includes(expression.type) &&
+        !(expression.sql.includes('IP_SEARCH') || expression.sql.includes('IP_MATCH'))
+      ) {
         return `${dialect.ipStringifyExpression(
           expression.getSQL(dialect),
         )} AS ${dialect.escapeName(name)}`;

--- a/src/expressions/splitExpression.ts
+++ b/src/expressions/splitExpression.ts
@@ -19,6 +19,7 @@ import { immutableLookupsEqual } from 'immutable-class';
 
 import { Dataset, Datum, PlywoodValue, Set } from '../datatypes/index';
 import { SQLDialect } from '../dialect/baseDialect';
+import { containsSqlFunction } from '../helper';
 import { DatasetFullType, FullType } from '../types';
 
 import {
@@ -204,7 +205,7 @@ export class SplitExpression extends ChainableExpression implements Aggregate {
       if (
         expression instanceof SqlRefExpression &&
         ['IP', 'SET/IP'].includes(expression.type) &&
-        !expression.sql.match(/ip_search\(|ip_match\(/gi)?.length
+        !containsSqlFunction(expression, ['ip_search', 'ip_match'])
       ) {
         return `${dialect.ipStringifyExpression(
           expression.getSQL(dialect),

--- a/src/expressions/splitExpression.ts
+++ b/src/expressions/splitExpression.ts
@@ -204,7 +204,10 @@ export class SplitExpression extends ChainableExpression implements Aggregate {
       if (
         expression instanceof SqlRefExpression &&
         ['IP', 'SET/IP'].includes(expression.type) &&
-        !(expression.sql.includes('IP_SEARCH') || expression.sql.includes('IP_MATCH'))
+        !(
+          expression.sql.toLowerCase().includes('ip_search') ||
+          expression.sql.toLowerCase().includes('ip_match')
+        )
       ) {
         return `${dialect.ipStringifyExpression(
           expression.getSQL(dialect),

--- a/src/expressions/splitExpression.ts
+++ b/src/expressions/splitExpression.ts
@@ -204,7 +204,6 @@ export class SplitExpression extends ChainableExpression implements Aggregate {
       if (
         expression instanceof SqlRefExpression &&
         ['IP', 'SET/IP'].includes(expression.type) &&
-        // Should not add IP_STRINGIFY around
         !expression.sql.match(/ip_search\(|ip_match\(/gi)?.length
       ) {
         return `${dialect.ipStringifyExpression(

--- a/src/expressions/splitExpression.ts
+++ b/src/expressions/splitExpression.ts
@@ -204,10 +204,8 @@ export class SplitExpression extends ChainableExpression implements Aggregate {
       if (
         expression instanceof SqlRefExpression &&
         ['IP', 'SET/IP'].includes(expression.type) &&
-        !(
-          expression.sql.toLowerCase().includes('ip_search') ||
-          expression.sql.toLowerCase().includes('ip_match')
-        )
+        // Should not add IP_STRINGIFY around
+        !expression.sql.match(/ip_search\(|ip_match\(/gi)?.length
       ) {
         return `${dialect.ipStringifyExpression(
           expression.getSQL(dialect),

--- a/src/helper/containsSqlFunction.ts
+++ b/src/helper/containsSqlFunction.ts
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-export * from './concurrentLimitRequester';
-export * from './containsSqlFunction';
-export * from './promiseWhile';
-export * from './retryRequester';
-export * from './utils';
-export * from './verboseRequester';
+import { SqlFunction } from 'druid-query-toolkit';
+
+import { SqlRefExpression } from '../expressions';
+
+export function containsSqlFunction(
+  expression: SqlRefExpression,
+  functionNames: string[],
+): boolean {
+  const lowerCaseFunctionNames = functionNames.map(functionName => functionName.toLowerCase());
+
+  return (
+    expression.parsedSql.type === 'function' &&
+    lowerCaseFunctionNames.includes(
+      (expression.parsedSql as SqlFunction).functionName.toLowerCase(),
+    )
+  );
+}

--- a/test/expression/splitExpression.mocha.js
+++ b/test/expression/splitExpression.mocha.js
@@ -61,21 +61,21 @@ describe('SplitExpression', () => {
   describe('getSelectSql', () => {
     it('should not add IP_STRINGIFY to IP_MATCH expression', () => {
       const splitExpression = Expression._.split({
-        ip: s$(`IP_MATCH('192', IP_PARSE(IP_STRINGIFY("t"."net_dst")))`, 'IP'),
+        ip: s$(`IP_MATCH('192', "t"."net_dst")`, 'IP'),
       });
 
       expect(splitExpression.getSelectSQL(dialect)[0]).to.equal(
-        `(IP_MATCH('192', IP_PARSE(IP_STRINGIFY("t"."net_dst")))) AS "ip"`,
+        `(IP_MATCH('192', "t"."net_dst")) AS "ip"`,
       );
     });
 
     it('should not add IP_STRINGIFY to IP_SEARCH expression', () => {
       const splitExpression = Expression._.split({
-        ip: s$(`IP_SEARCH('192', IP_PREFIX_PARSE(IP_STRINGIFY("t"."net_dst")))`, 'IP'),
+        ip: s$(`IP_SEARCH('192', "t"."net_dst")`, 'IP'),
       });
 
       expect(splitExpression.getSelectSQL(dialect)[0]).to.equal(
-        `(IP_SEARCH('192', IP_PREFIX_PARSE(IP_STRINGIFY("t"."net_dst")))) AS "ip"`,
+        `(IP_SEARCH('192', "t"."net_dst")) AS "ip"`,
       );
     });
 

--- a/test/expression/splitExpression.mocha.js
+++ b/test/expression/splitExpression.mocha.js
@@ -18,7 +18,9 @@ const { expect } = require('chai');
 
 const plywood = require('../plywood');
 
-const { $, ply, r, Expression } = plywood;
+const { s$, $, ply, r, Expression, DruidDialect } = plywood;
+
+const dialect = new DruidDialect();
 
 describe('SplitExpression', () => {
   describe('#maxBucketNumber', () => {
@@ -53,6 +55,38 @@ describe('SplitExpression', () => {
       });
 
       expect(splitExpression.maxBucketNumber()).to.equal(Infinity);
+    });
+  });
+
+  describe('getSelectSql', () => {
+    it('should not add IP_STRINGIFY to IP_MATCH expression', () => {
+      const splitExpression = Expression._.split({
+        ip: s$(`IP_MATCH('192', IP_PARSE(IP_STRINGIFY("t"."net_dst")))`, 'IP'),
+      });
+
+      expect(splitExpression.getSelectSQL(dialect)[0]).to.equal(
+        `(IP_MATCH('192', IP_PARSE(IP_STRINGIFY("t"."net_dst")))) AS "ip"`,
+      );
+    });
+
+    it('should not add IP_STRINGIFY to IP_SEARCH expression', () => {
+      const splitExpression = Expression._.split({
+        ip: s$(`IP_SEARCH('192', IP_PREFIX_PARSE(IP_STRINGIFY("t"."net_dst")))`, 'IP'),
+      });
+
+      expect(splitExpression.getSelectSQL(dialect)[0]).to.equal(
+        `(IP_SEARCH('192', IP_PREFIX_PARSE(IP_STRINGIFY("t"."net_dst")))) AS "ip"`,
+      );
+    });
+
+    it('should add IP_STRINGIFY to ip expression without functions', () => {
+      const splitExpression = Expression._.split({
+        ip: s$(`"t"."net_dst"`, 'IP'),
+      });
+
+      expect(splitExpression.getSelectSQL(dialect)[0]).to.equal(
+        `IP_STRINGIFY(("t"."net_dst")) AS "ip"`,
+      );
     });
   });
 });

--- a/test/expression/splitExpression.mocha.js
+++ b/test/expression/splitExpression.mocha.js
@@ -88,5 +88,25 @@ describe('SplitExpression', () => {
         `IP_STRINGIFY(("t"."net_dst")) AS "ip"`,
       );
     });
+
+    it('should add IP_STRINGIFY to ip expression if the column name is ip_match', () => {
+      const splitExpression = Expression._.split({
+        ip: s$(`"t"."ip_match"`, 'IP'),
+      });
+
+      expect(splitExpression.getSelectSQL(dialect)[0]).to.equal(
+        `IP_STRINGIFY(("t"."ip_match")) AS "ip"`,
+      );
+    });
+
+    it('should add IP_STRINGIFY to ip expression if the column name is ip_search', () => {
+      const splitExpression = Expression._.split({
+        ip: s$(`"t"."ip_search"`, 'IP'),
+      });
+
+      expect(splitExpression.getSelectSQL(dialect)[0]).to.equal(
+        `IP_STRINGIFY(("t"."ip_search")) AS "ip"`,
+      );
+    });
   });
 });

--- a/test/helper/containsSqlFunction.mocha.js
+++ b/test/helper/containsSqlFunction.mocha.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2015 Metamarkets Group Inc.
+ * Copyright 2015-2020 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { expect } = require('chai');
+
+const { s$, containsSqlFunction } = require('../../build/plywood');
+
+describe('containsSqlFunction', () => {
+  it('should return false if function is not a part of the SqlRefExpression', () => {
+    expect(containsSqlFunction(s$(`IP_SEARCH('192', "t"."net_dst")`, 'IP'), ['ip_match'])).to.equal(
+      false,
+    );
+  });
+
+  it('should return true if function is a part of the SqlRefExpression', () => {
+    expect(
+      containsSqlFunction(s$(`IP_SEARCH('192', "t"."net_dst")`, 'IP'), ['ip_search']),
+    ).to.equal(true);
+  });
+
+  it('should return false if column name is the same as function name', () => {
+    expect(containsSqlFunction(s$(`"t"."ip_search"`, 'IP'), ['ip_search'])).to.equal(false);
+  });
+
+  it('should be case insensitive', () => {
+    expect(
+      containsSqlFunction(s$(`ip_search('192', "t"."net_dst")`, 'IP'), ['IP_SEARCH']),
+    ).to.equal(false);
+  });
+});


### PR DESCRIPTION
If a SqlRefExpression.sql was `IP_SEARCH('192', IP_PREFIX_PARSE(IP_STRINGIFY("t"."net_dst")))` then SplitExpression.getSelectSql would incorrectly wrap this value with IP_STRINGIFY. And apparently I forgot to push the version update changes for `0.30.2` so those are in here.