### PR TITLE
Added _calcChainableHelper for mvOverlapExpression and mvContainsExpression

### DIFF
--- a/src/expressions/mvContainsExpression.ts
+++ b/src/expressions/mvContainsExpression.ts
@@ -64,7 +64,7 @@ export class MvContainsExpression extends ChainableExpression {
       typeof operandValue === 'string'
         ? [operandValue]
         : Array.isArray(operandValue)
-        ? [...operandValue]
+        ? operandValue
         : [];
     return operandArray.every(element => this.mvArray.includes(element));
   }

--- a/src/expressions/mvContainsExpression.ts
+++ b/src/expressions/mvContainsExpression.ts
@@ -66,7 +66,7 @@ export class MvContainsExpression extends ChainableExpression {
         : Array.isArray(operandValue)
         ? [...operandValue]
         : [];
-    return this.mvArray.some(element => operandArray.includes(element));
+    return operandArray.every(element => this.mvArray.includes(element));
   }
 
   protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {

--- a/src/expressions/mvContainsExpression.ts
+++ b/src/expressions/mvContainsExpression.ts
@@ -16,6 +16,7 @@
 
 import { generalArraysEqual } from 'immutable-class';
 
+import { PlywoodValue } from '../datatypes/index';
 import { SQLDialect } from '../dialect/baseDialect';
 
 import { ChainableExpression, Expression, ExpressionJS, ExpressionValue } from './baseExpression';
@@ -56,6 +57,16 @@ export class MvContainsExpression extends ChainableExpression {
 
   protected _toStringParameters(_indent?: int): string[] {
     return this.mvArray;
+  }
+
+  protected _calcChainableHelper(operandValue: any): PlywoodValue {
+    const operandArray =
+      typeof operandValue === 'string'
+        ? [operandValue]
+        : Array.isArray(operandValue)
+        ? [...operandValue]
+        : [];
+    return this.mvArray.some(element => operandArray.includes(element));
   }
 
   protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {

--- a/src/expressions/mvOverlapExpression.ts
+++ b/src/expressions/mvOverlapExpression.ts
@@ -16,6 +16,7 @@
 
 import { generalArraysEqual } from 'immutable-class';
 
+import { PlywoodValue } from '../datatypes/index';
 import { SQLDialect } from '../dialect/baseDialect';
 
 import { ChainableExpression, Expression, ExpressionJS, ExpressionValue } from './baseExpression';
@@ -56,6 +57,16 @@ export class MvOverlapExpression extends ChainableExpression {
 
   protected _toStringParameters(_indent?: int): string[] {
     return this.mvArray;
+  }
+
+  protected _calcChainableHelper(operandValue: any): PlywoodValue {
+    const operandArray =
+      typeof operandValue === 'string'
+        ? [operandValue]
+        : Array.isArray(operandValue)
+        ? [...operandValue]
+        : null;
+    return operandArray !== null && operandArray.every(element => this.mvArray.includes(element));
   }
 
   protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {

--- a/src/expressions/mvOverlapExpression.ts
+++ b/src/expressions/mvOverlapExpression.ts
@@ -64,7 +64,7 @@ export class MvOverlapExpression extends ChainableExpression {
       typeof operandValue === 'string'
         ? [operandValue]
         : Array.isArray(operandValue)
-        ? [...operandValue]
+        ? operandValue
         : null;
     return operandArray !== null && operandArray.some(element => this.mvArray.includes(element));
   }

--- a/src/expressions/mvOverlapExpression.ts
+++ b/src/expressions/mvOverlapExpression.ts
@@ -66,7 +66,7 @@ export class MvOverlapExpression extends ChainableExpression {
         : Array.isArray(operandValue)
         ? [...operandValue]
         : null;
-    return operandArray !== null && operandArray.every(element => this.mvArray.includes(element));
+    return operandArray !== null && operandArray.some(element => this.mvArray.includes(element));
   }
 
   protected _getSQLChainableHelper(dialect: SQLDialect, operandSQL: string): string {

--- a/test/expression/mvContainsExpression.mocha.js
+++ b/test/expression/mvContainsExpression.mocha.js
@@ -21,29 +21,28 @@ const plywood = require('../plywood');
 
 const { Expression } = plywood;
 
-describe('MvOverlapExpression', () => {
+describe('MvContainsExpression', () => {
   describe('_calcChainableHelper', () => {
     it('works with single string', () => {
-      const mvOverlapExpression = Expression._.mvOverlap([
+      const mvContainsExpression = Expression._.mvContains([
         'thing',
         'otherThing',
         'otherOtherThing',
       ]);
 
-      expect(mvOverlapExpression._calcChainableHelper('thing')).to.equal(true);
-      expect(mvOverlapExpression._calcChainableHelper('not a thing')).to.equal(false);
+      expect(mvContainsExpression._calcChainableHelper('thing')).to.equal(true);
+      expect(mvContainsExpression._calcChainableHelper('not a thing')).to.equal(false);
     });
 
     it('works with array of strings', () => {
-      const mvOverlapExpression = Expression._.mvOverlap([
+      const mvContainsExpression = Expression._.mvContains([
         'thing',
         'otherThing',
         'otherOtherThing',
       ]);
 
-      expect(mvOverlapExpression._calcChainableHelper(['thing', 'otherThing'])).to.equal(true);
-      expect(mvOverlapExpression._calcChainableHelper(['not a thing'])).to.equal(false);
-      expect(mvOverlapExpression._calcChainableHelper(['thing', 'not a thing'])).to.equal(true);
+      expect(mvContainsExpression._calcChainableHelper(['thing', 'otherThing'])).to.equal(true);
+      expect(mvContainsExpression._calcChainableHelper(['thing', 'not a thing'])).to.equal(false);
     });
   });
 });

--- a/test/expression/mvOverlapExpression.mocha.js
+++ b/test/expression/mvOverlapExpression.mocha.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012-2015 Metamarkets Group Inc.
+ * Copyright 2015-2020 Imply Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { expect } = require('chai');
+
+const plywood = require('../plywood');
+const { SQLDialect } = require('../plywood');
+
+const { $, ply, r, Expression, MvOverlapExpression, Set } = plywood;
+
+class TestingDialect extends SQLDialect {
+  constructor() {
+    super();
+  }
+}
+
+describe('MvOverlapExpression', () => {
+
+  describe('_getSQLChainableUnaryHelper', () => {
+    it('works', () => {
+      const mvOverlapExpression = Expression._.mvOverlap([
+        'thing',
+        'otherThing',
+        'otherOtherThing',
+      ]);
+      const dialect = new TestingDialect();
+
+      expect(mvOverlapExpression._getSQLChainableUnaryHelper(dialect, ['thing'])).to.equal(
+        `MV_OVERLAP(['thing', 'otherThing', 'otherOtherThing'], ['thing'])`,
+      );
+    });
+  });
+
+  describe('_calcChainableHelper', () => {
+    it('works with single string', () => {
+      const mvOverlapExpression = Expression._.mvOverlap([
+        'thing',
+        'otherThing',
+        'otherOtherThing',
+      ]);
+
+      expect(mvOverlapExpression._getSQLChainableUnaryHelper('thing')).to.equal(true);
+      expect(mvOverlapExpression._getSQLChainableUnaryHelper('not a thing')).to.equal(false);
+    });
+
+    it('works with array of strings', () => {
+      const mvOverlapExpression = Expression._.mvOverlap([
+        'thing',
+        'otherThing',
+        'otherOtherThing',
+      ]);
+
+      expect(mvOverlapExpression._getSQLChainableUnaryHelper(['thing', 'otherThing'])).to.equal(
+        true,
+      );
+      expect(mvOverlapExpression._getSQLChainableUnaryHelper(['not a thing'])).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Jira Task: [IMPLY-29907](https://implydata.atlassian.net/browse/IMPLY-29907)

Context:
The error described in the ticket occurs because clicking on the color legend triggers `FilterClause.matches()` , which calls Expression.calc() inside. (https://github.com/implydata/imply-ui/blob/master/packages/pivot-common/src/models/filter-clause/filter-clause.ts#L469). For `MvOverlapExpression` and `MvContainsExpression` in Plywood, this function is not implemented.

[IMPLY-29907]: https://implydata.atlassian.net/browse/IMPLY-29907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ