### PR TITLE
add a null check to the accumulator in set.ts [IMPLY-32068]

### DIFF
--- a/src/datatypes/set.ts
+++ b/src/datatypes/set.ts
@@ -75,7 +75,9 @@ export class Set implements Instance<SetValue, SetJS> {
           delete newElements[newElementsKey];
         }
       }
-      newElements[accumulator.toString()] = accumulator;
+      if (accumulator) {
+        newElements[accumulator.toString()] = accumulator;
+      }
     }
     const newElementsKeys = Object.keys(newElements);
     return newElementsKeys.length < elements.length


### PR DESCRIPTION
Set.unifyElements elements should check that the accumulator is not null before adding it to new values. This will filter out null values and it will no longer throw an error. 

before: 
<img width="999" alt="Screen Shot 2023-04-18 at 1 13 44 PM" src="https://user-images.githubusercontent.com/37322608/232894892-5dfcc405-dc50-4d4b-a2f1-41c760055869.png">

after: 
<img width="1020" alt="Screen Shot 2023-04-18 at 1 02 48 PM" src="https://user-images.githubusercontent.com/37322608/232894998-56a74e00-d932-42f4-9ecc-92ece444b87f.png">

