### PR TITLE
add special cases for csv and tsv formatting [IMPLY-34859]

### DIFF
--- a/src/datatypes/dataset.ts
+++ b/src/datatypes/dataset.ts
@@ -316,7 +316,7 @@ export class Dataset implements Instance<DatasetValue, DatasetJS> {
   static CSV_FINALIZER: Finalizer = (v: string) => {
     v = removeLineBreaks(v);
     if (v === 'null') return '';
-    if (v !== '' && v.indexOf('"') === -1 && v.indexOf(',') === -1) return v;
+    if (v === '') return `""`;
     if (v.indexOf('"') === -1 && v.indexOf(',') === -1) return v;
     return `"${v.replace(/"/g, '""')}"`;
   };

--- a/src/datatypes/dataset.ts
+++ b/src/datatypes/dataset.ts
@@ -315,12 +315,17 @@ export class Dataset implements Instance<DatasetValue, DatasetJS> {
 
   static CSV_FINALIZER: Finalizer = (v: string) => {
     v = removeLineBreaks(v);
+    if (v === 'null') return '';
+    if (v !== '' && v.indexOf('"') === -1 && v.indexOf(',') === -1) return v;
     if (v.indexOf('"') === -1 && v.indexOf(',') === -1) return v;
     return `"${v.replace(/"/g, '""')}"`;
   };
 
   static TSV_FINALIZER: Finalizer = (v: string) => {
-    return removeLineBreaks(v).replace(/\t/g, '').replace(/"/g, '""');
+    v = removeLineBreaks(v).replace(/\t/g, '');
+    if (v === 'null') return '';
+    if (v === '') return `""`;
+    return v.replace(/"/g, '""');
   };
 
   static datumToLine(


### PR DESCRIPTION
We want null columns to be represented by a space and empty strings to be represented by "". To support this we need to add in special logic in both the TSV and CSV finalizers to return the right values. 
<img width="565" alt="Screen Shot 2023-07-04 at 3 44 32 PM" src="https://github.com/implydata/plywood/assets/37322608/ca4b8404-d88f-458e-9fa9-a802574c883a">
<img width="265" alt="Screen Shot 2023-07-04 at 3 44 04 PM" src="https://github.com/implydata/plywood/assets/37322608/a2c5eca8-df07-48c0-870c-856066b58148">
