### PR TITLE
Dataset.fromJs creates an empty Set if type is SET

### DIFF
--- a/src/datatypes/common.ts
+++ b/src/datatypes/common.ts
@@ -102,7 +102,7 @@ export function valueFromJS(v: any, typeOverride: string | null = null): any {
   if (v == null) {
     return null;
   } else if (Array.isArray(v)) {
-    if (v.length && typeof v[0] !== 'object') {
+    if ((v.length && typeof v[0] !== 'object') || String(typeOverride).indexOf('SET') === 0) {
       return Set.fromJS(v);
     } else {
       return Dataset.fromJS(v);


### PR DESCRIPTION
Currently, creation of datums via `.fromJs` ignores the attribute type if the value is an empty array
```
const dataset = Dataset.fromJs({
  attributes: [ { name: 'x', type: 'SET }]
  data: [ { x: [] }, { x: ['foo'] } ]
})

// dataset.data[0] is a Dataset
// dataset.data[1] is a Set

```
This fix checks attribute type so that there aren't a mix of types on `.data`